### PR TITLE
Remove Foldable and Traversable instances from MaybeTable and TheseTable

### DIFF
--- a/Rel8/Internal/Table.hs
+++ b/Rel8/Internal/Table.hs
@@ -21,9 +21,7 @@ import Control.Applicative
 import Control.Lens (Iso', from, iso, view)
 import Control.Monad (replicateM_)
 import Data.Aeson (FromJSON, ToJSON)
-import Data.Bifoldable ( Bifoldable, bifoldMap )
 import Data.Bifunctor ( Bifunctor, bimap )
-import Data.Bitraversable ( Bitraversable, bitraverse )
 import Data.Foldable (traverse_)
 import Data.Functor.Identity
 import Data.Functor.Product
@@ -147,7 +145,7 @@ instance DBType a =>
 -- | Indicates that a given 'Table' might be @null@. This is the result of a
 -- @LEFT JOIN@ between tables.
 data MaybeTable row = MaybeTable (Expr (Maybe Bool)) row
-  deriving (Foldable, Functor, Traversable)
+  deriving Functor
 
 instance Applicative MaybeTable where
   pure = MaybeTable (lit (Just False))
@@ -216,19 +214,11 @@ maybeTable b f (MaybeTable tag a) =
 -- | A pair of 'Table's where at most one might be @null@. This is the result of
 -- an @FULL OUTER JOIN@ between tables.
 data TheseTable a b = TheseTable (MaybeTable a) (MaybeTable b)
-  deriving (Foldable, Functor, Traversable)
-
-
-instance Bifoldable TheseTable where
-  bifoldMap f g (TheseTable a b) = foldMap f a <> foldMap g b
+  deriving Functor
 
 
 instance Bifunctor TheseTable where
   bimap f g (TheseTable a b) = TheseTable (fmap f a) (fmap g b)
-
-
-instance Bitraversable TheseTable where
-  bitraverse f g (TheseTable a b) = TheseTable <$> traverse f a <*> traverse g b
 
 
 -- | The result of a full outer join is a pair of tables, but one of the tables


### PR DESCRIPTION
They were unsafe. A simple "proof" of this is that you can implement a `fromJust :: MaybeTable a -> a` with just `head . toList`.