### PR TITLE
Allow for schema qualified table names

### DIFF
--- a/Rel8.hs
+++ b/Rel8.hs
@@ -24,7 +24,7 @@ module Rel8
     C
   , Anon
   , HasDefault(..)
-  , BaseTable(tableName)
+  , BaseTable(tableName, tableSchema)
   , Table
 
     -- * Querying Tables

--- a/Rel8/Internal/Table.hs
+++ b/Rel8/Internal/Table.hs
@@ -382,8 +382,6 @@ class Table (table Expr) (table QueryResult) => BaseTable table where
 
   ------------------------------------------------------------------------------
 
-  default
-    tableSchema :: Maybe ( Tagged table String )
   tableSchema = Nothing
 
   default


### PR DESCRIPTION
When the `tableSchema` is defined, refer to the table using the
schema-qualified table name. By doing this tables in other schemas may
be queried instead of adjusting the defined `search_path` for the
database connections.

Opaleye already supports this and this PR surfaces this functionality
in the definition for `BaseTable`.