### PR TITLE
Add renameColumns and defaultNames

### DIFF
--- a/Rel8.hs
+++ b/Rel8.hs
@@ -99,6 +99,10 @@ module Rel8
     -- * Values
   , values
 
+    -- * Rename columns
+  , Bindings, renameColumns
+  , DefaultNames, defaultNames
+
     -- * Running Queries
     -- ** @SELECT@
   , select
@@ -114,7 +118,7 @@ module Rel8
   , delete
 
     -- * Interpretations
-  , QueryResult, SchemaInfo
+  , QueryResult, SchemaInfo, Name
 
     -- * Re-exported symbols
   , Connection, Stream, Of, Generic

--- a/Rel8/Internal/Types.hs
+++ b/Rel8/Internal/Types.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE PolyKinds #-}
@@ -8,6 +9,7 @@
 
 module Rel8.Internal.Types where
 
+import Data.String ( IsString )
 import Rel8.Internal.Expr
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as O
 
@@ -28,6 +30,12 @@ data Insert a = InsertExpr (Expr a)
 data SchemaInfo a =
   SchemaInfo String
   deriving (Show)
+
+
+--------------------------------------------------------------------------------
+-- | Used for naming the columns of a query with 'renameColumns'.
+newtype Name a = Name String
+  deriving (IsString, Show)
 
 
 --------------------------------------------------------------------------------
@@ -62,6 +70,7 @@ type family C f columnName hasDefault columnType :: * where
   C Insert name 'HasDefault t = Default (Expr t)
   C Insert name 'NoDefault t = Expr t
   C Aggregate name _ t = Aggregate t
+  C Name _ _ t = Name t
 
 -- | @Anon@ can be used to define columns like 'C', but does not contain the
 -- extra metadata needed to define a 'BaseTable' instance. The main use of
@@ -89,6 +98,7 @@ type family Anon f columnType :: * where
   Anon Expr t = Expr t
   Anon QueryResult t = t
   Anon Aggregate t = Aggregate t
+  Anon Name t = Name t
 
 newtype Limit f = Limit
   { runLimit :: forall a. f a


### PR DESCRIPTION
`renameColumns` allows a query to specify the SQL names of the underlying columns it returns. For a `HigherKindedTable t`, this is given in the form of `t Name`, where `Name` is a new interpretation functor with an `IsString` instance. `defaultNames` gives a default set of names for a type that's derived generically from its record field names.