### PR TITLE
Make Rel8able have kind ((X -> Type) -> Type) -> Constraint

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -113,6 +113,7 @@ library
     Rel8.Schema.Kind
     Rel8.Schema.Name
     Rel8.Schema.Null
+    Rel8.Schema.Result
     Rel8.Schema.Spec
     Rel8.Schema.Spec.ConstrainDBType
     Rel8.Schema.Spec.ConstrainType

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -235,6 +235,7 @@ module Rel8
   , Labelable
   , ToExprs(..)
   , FromExprs
+  , Result
   ) where
 
 -- base
@@ -277,6 +278,7 @@ import Rel8.Schema.Generic
 import Rel8.Schema.HTable
 import Rel8.Schema.Name
 import Rel8.Schema.Null hiding ( nullable )
+import Rel8.Schema.Result
 import Rel8.Schema.Table
 import Rel8.Statement.Delete
 import Rel8.Statement.Insert

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -26,7 +26,7 @@ module Rel8
   , DBFractional
 
     -- * Tables and higher-kinded tables
-  , Rel8able
+  , Rel8able, KRel8able
   , Column, Field, Necessity( Required, Optional )
   , Default
   , HMaybe

--- a/src/Rel8/Expr.hs-boot
+++ b/src/Rel8/Expr.hs-boot
@@ -1,3 +1,5 @@
+{-# language GADTs #-}
+{-# language PolyKinds #-}
 {-# language RoleAnnotations #-}
 {-# language StandaloneKindSignatures #-}
 
@@ -15,5 +17,6 @@ import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
 
 
 type role Expr representational
-type Expr :: Type -> Type
-newtype Expr a = Expr Opaleye.PrimExpr
+type Expr :: k -> Type
+data Expr a where
+  Expr :: k ~ Type => !Opaleye.PrimExpr -> Expr (a :: k)

--- a/src/Rel8/Expr/Bool.hs
+++ b/src/Rel8/Expr/Bool.hs
@@ -1,3 +1,5 @@
+{-# language GADTs #-}
+
 module Rel8.Expr.Bool
   ( false, true
   , (&&.), (||.), not_
@@ -17,7 +19,7 @@ import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
 
 -- rel8
 import {-# SOURCE #-} Rel8.Expr ( Expr( Expr ) )
-import Rel8.Expr.Opaleye ( mapPrimExpr, zipPrimExprsWith )
+import Rel8.Expr.Opaleye ( mapPrimExpr, toPrimExpr, zipPrimExprsWith )
 import Rel8.Expr.Serialize ( litExpr )
 
 
@@ -75,7 +77,7 @@ caseExpr :: [(Expr Bool, Expr a)] -> Expr a -> Expr a
 caseExpr branches (Expr fallback) =
   Expr $ Opaleye.CaseExpr (map go branches) fallback
   where
-    go (Expr condition, Expr value) = (condition, value)
+    go (condition, value) = (toPrimExpr condition, toPrimExpr value)
 
 
 -- | Convert a @Expr (Maybe Bool)@ to a @Expr Bool@ by treating @Nothing@ as

--- a/src/Rel8/Expr/Null.hs
+++ b/src/Rel8/Expr/Null.hs
@@ -78,6 +78,7 @@ liftOpNull :: DBType c
 liftOpNull f ma mb =
   boolExpr (unsafeLiftOpNull f ma mb) null
     (isNull ma ||. isNull mb)
+{-# INLINABLE liftOpNull #-}
 
 
 snull :: TypeInformation a -> Expr (Maybe a)

--- a/src/Rel8/Expr/Ord.hs
+++ b/src/Rel8/Expr/Ord.hs
@@ -23,7 +23,7 @@ import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
 import Rel8.Expr ( Expr( Expr ) )
 import Rel8.Expr.Bool ( (&&.), (||.), coalesce )
 import Rel8.Expr.Null ( isNull, isNonNull, nullable, unsafeLiftOpNull )
-import Rel8.Expr.Opaleye ( zipPrimExprsWith )
+import Rel8.Expr.Opaleye ( toPrimExpr, zipPrimExprsWith )
 import Rel8.Schema.Null ( Nullity( Null, NotNull ), Sql )
 import qualified Rel8.Schema.Null as Schema ( nullable )
 import Rel8.Type.Ord ( DBOrd )
@@ -122,7 +122,7 @@ leastExpr ma mb = case Schema.nullable @a of
   Null -> nullable ma (\a -> nullable mb (least_ a) mb) ma
   NotNull -> least_ ma mb
   where
-    least_ (Expr a) (Expr b) = Expr (Opaleye.FunExpr "LEAST" [a, b])
+    least_ a b = Expr (Opaleye.FunExpr "LEAST" [toPrimExpr a, toPrimExpr b])
 
 
 -- | Given two expressions, return the expression that sorts greater than the
@@ -134,4 +134,5 @@ greatestExpr ma mb = case Schema.nullable @a of
   Null -> nullable mb (\a -> nullable ma (greatest_ a) mb) ma
   NotNull -> greatest_ ma mb
   where
-    greatest_ (Expr a) (Expr b) = Expr (Opaleye.FunExpr "GREATEST" [a, b])
+    greatest_ a b =
+      Expr (Opaleye.FunExpr "GREATEST" [toPrimExpr a, toPrimExpr b])

--- a/src/Rel8/Schema/Context.hs
+++ b/src/Rel8/Schema/Context.hs
@@ -9,12 +9,12 @@ module Rel8.Schema.Context
 where
 
 -- base
-import Data.Functor.Identity ( Identity )
 import Data.Kind ( Constraint )
 import Prelude ()
 
 -- rel8
 import Rel8.Schema.Kind ( Context, HContext )
+import Rel8.Schema.Result ( Result )
 import Rel8.Schema.Spec ( Spec( Spec ) )
 
 
@@ -23,6 +23,6 @@ class Interpretation context where
   data Col context :: HContext
 
 
-instance Interpretation Identity where
-  data Col Identity _spec where
-    Result :: a -> Col Identity ('Spec labels necessity a)
+instance Interpretation Result where
+  data Col Result _spec where
+    Result :: a -> Col Result ('Spec labels necessity a)

--- a/src/Rel8/Schema/Context/Label.hs
+++ b/src/Rel8/Schema/Context/Label.hs
@@ -11,7 +11,6 @@ module Rel8.Schema.Context.Label
 where
 
 -- base
-import Data.Functor.Identity ( Identity )
 import Data.Kind ( Constraint )
 import Prelude hiding ( null )
 
@@ -20,6 +19,7 @@ import Rel8.Schema.Context ( Interpretation, Col(..) )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.Kind ( Context, HContext )
 import Rel8.Schema.Spec ( Spec( Spec ) )
+import Rel8.Schema.Result ( Result )
 import Rel8.Schema.Spec.ConstrainDBType ( ConstrainDBType )
 
 
@@ -34,7 +34,7 @@ class Interpretation context => Labelable context where
     -> Col context ('Spec labels necessity a)
 
 
-instance Labelable Identity where
+instance Labelable Result where
   labeler (Result a) = Result a
   unlabeler (Result a) = Result a
 

--- a/src/Rel8/Schema/Generic.hs
+++ b/src/Rel8/Schema/Generic.hs
@@ -43,7 +43,6 @@ import Rel8.Schema.HTable.Label ( HLabel, hlabel, hunlabel )
 import Rel8.Schema.HTable.Pair ( HPair(..) )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name )
-import Rel8.Schema.Spec ( KTable )
 import Rel8.Table
   ( Table, Columns, Context, fromColumns, toColumns
   )
@@ -104,7 +103,7 @@ instance
 -- data MyType f = MyType { fieldA :: Column f T }
 --   deriving ( GHC.Generics.Generic, Rel8able )
 -- @
-type Rel8able :: KTable -> Constraint
+type Rel8able :: K.Table -> Constraint
 class HTable (GRep t) => Rel8able t where
   gfromColumns :: (Labelable context, Reifiable context)
     => GRep t (Col (Reify context)) -> t (Reify context)

--- a/src/Rel8/Schema/Generic.hs
+++ b/src/Rel8/Schema/Generic.hs
@@ -18,6 +18,7 @@
 
 module Rel8.Schema.Generic
   ( Rel8able
+  , KRel8able
   )
 where
 
@@ -59,6 +60,10 @@ instance
 
   fromColumns = unreify . gfromColumns . hreify
   toColumns = hunreify . gtoColumns . reify
+
+
+type KRel8able :: Type
+type KRel8able = K.Table
 
 
 -- | This type class allows you to define custom 'Table's using higher-kinded
@@ -103,7 +108,7 @@ instance
 -- data MyType f = MyType { fieldA :: Column f T }
 --   deriving ( GHC.Generics.Generic, Rel8able )
 -- @
-type Rel8able :: K.Table -> Constraint
+type Rel8able :: KRel8able -> Constraint
 class HTable (GRep t) => Rel8able t where
   gfromColumns :: (Labelable context, Reifiable context)
     => GRep t (Col (Reify context)) -> t (Reify context)

--- a/src/Rel8/Schema/Insert.hs
+++ b/src/Rel8/Schema/Insert.hs
@@ -6,6 +6,7 @@
 {-# language LambdaCase #-}
 {-# language MultiParamTypeClasses #-}
 {-# language NamedFieldPuns #-}
+{-# language PolyKinds #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeFamilies #-}
 {-# language UndecidableInstances #-}
@@ -36,9 +37,9 @@ import Rel8.Schema.Context.Nullify
   , runTag, unnull
   )
 import Rel8.Schema.HTable.Type ( HType( HType ) )
-import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name, Selects )
 import Rel8.Schema.Null ( Sql )
+import Rel8.Schema.Result ( Result )
 import Rel8.Schema.Spec ( SSpec(SSpec, nullity), Spec(Spec) )
 import Rel8.Schema.Table ( TableSchema )
 import Rel8.Statement.Returning ( Returning )
@@ -56,7 +57,7 @@ data OnConflict
 
 
 -- | The constituent parts of a SQL @INSERT@ statement.
-type Insert :: K.Context
+type Insert :: k -> Type
 data Insert a where
   Insert :: (Selects names exprs, Inserts exprs inserts) =>
     { into :: TableSchema names
@@ -78,7 +79,7 @@ instance Interpretation Insert where
     OptionalInsert :: Maybe (Expr a) -> Col Insert ('Spec labels 'Optional a)
 
 
-type Insertion :: K.Context
+type Insertion :: Type -> Type
 newtype Insertion a = Insertion (Expr a)
 
 
@@ -98,7 +99,7 @@ instance Sql DBType a => Recontextualize Expr Insert (Expr a) (Insertion a)
 
 
 instance Sql DBType a =>
-  Recontextualize Identity Insert (Identity a) (Insertion a)
+  Recontextualize Result Insert (Identity a) (Insertion a)
 
 
 instance Sql DBType a =>
@@ -109,7 +110,7 @@ instance Sql DBType a => Recontextualize Insert Expr (Insertion a) (Expr a)
 
 
 instance Sql DBType a =>
-  Recontextualize Insert Identity (Insertion a) (Identity a)
+  Recontextualize Insert Result (Insertion a) (Identity a)
 
 
 instance Sql DBType a => Recontextualize Insert Insert (Insertion a) (Insertion a)

--- a/src/Rel8/Schema/Kind.hs
+++ b/src/Rel8/Schema/Kind.hs
@@ -22,8 +22,11 @@ type HTable :: Type
 type HTable = HContext -> Type
 
 
+data X
+
+
 type Context :: Type
-type Context = Type -> Type
+type Context = X -> Type
 
 
 type Table :: Type

--- a/src/Rel8/Schema/Result.hs
+++ b/src/Rel8/Schema/Result.hs
@@ -1,0 +1,16 @@
+{-# language DataKinds #-}
+{-# language StandaloneKindSignatures #-}
+
+module Rel8.Schema.Result
+  ( Result
+  ) where
+
+-- base
+import Prelude ()
+
+-- rel8
+import Rel8.Schema.Kind ( Context )
+
+
+type Result :: Context
+data Result a

--- a/src/Rel8/Schema/Spec.hs
+++ b/src/Rel8/Schema/Spec.hs
@@ -8,8 +8,6 @@ module Rel8.Schema.Spec
   ( Spec( Spec )
   , SSpec( SSpec, labels, necessity, info, nullity )
   , KnownSpec( specSing )
-  , KContext, HKTable
-  , KTable
   )
 where
 
@@ -62,15 +60,3 @@ instance
     , info = typeInformation
     , nullity = nullable
     }
-
-
-type KContext :: Type
-type KContext = Spec -> Type
-
-
-type HKTable :: Type
-type HKTable = KContext -> Type
-
-
-type KTable :: Type
-type KTable = (Type -> Type) -> Type

--- a/src/Rel8/Table/Eq.hs
+++ b/src/Rel8/Table/Eq.hs
@@ -40,6 +40,7 @@ import Rel8.Schema.HTable.Pair ( HPair(..) )
 import Rel8.Schema.HTable.Quartet ( HQuartet(..) )
 import Rel8.Schema.HTable.Quintet ( HQuintet(..) )
 import Rel8.Schema.HTable.Trio ( HTrio(..) )
+import Rel8.Schema.Kind ( Context )
 import Rel8.Schema.Null ( Sql )
 import Rel8.Schema.Spec.ConstrainDBType ( ConstrainDBType )
 import Rel8.Table ( Table, Columns, toColumns )
@@ -60,7 +61,7 @@ class Table Expr a => EqTable a where
 
 
 instance
-  ( Table Expr (t Expr)
+  ( Table Expr (t (Expr :: Context))
   , f ~ Expr
   , HConstrainTable (Columns (t Expr)) (ConstrainDBType DBEq)
   )

--- a/src/Rel8/Table/Name.hs
+++ b/src/Rel8/Table/Name.hs
@@ -23,8 +23,12 @@ import Prelude
 -- casing
 import Text.Casing ( quietSnake )
 
+-- opaleye
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
+
 -- rel8
 import Rel8.Expr ( Expr, Col(..) )
+import Rel8.Expr.Opaleye ( toPrimExpr )
 import Rel8.Kind.Labels ( renderLabels )
 import Rel8.Schema.HTable ( htabulate, htabulateA, hfield, hspecs )
 import Rel8.Schema.Name ( Name, Col(..) )
@@ -45,11 +49,11 @@ namesFromLabelsWith f = fromColumns $ htabulate $ \field ->
     SSpec {labels} -> NameCol (f (renderLabels labels))
 
 
-showExprs :: Table Expr a => a -> [(String, String)]
+showExprs :: Table Expr a => a -> [(String, Opaleye.PrimExpr)]
 showExprs as = case (namesFromLabels, toColumns as) of
   (names, exprs) -> getConst $ htabulateA $ \field ->
     case (hfield names field, hfield exprs field) of
-      (NameCol name, DB expr) -> Const [(name, show expr)]
+      (NameCol name, DB expr) -> Const [(name, toPrimExpr expr)]
 
 
 showLabels :: forall a. Table (Context a) a => a -> [NonEmpty String]

--- a/src/Rel8/Table/Ord.hs
+++ b/src/Rel8/Table/Ord.hs
@@ -37,6 +37,7 @@ import Rel8.Schema.HTable.Pair ( HPair(..) )
 import Rel8.Schema.HTable.Quartet ( HQuartet(..) )
 import Rel8.Schema.HTable.Quintet ( HQuintet(..) )
 import Rel8.Schema.HTable.Trio ( HTrio(..) )
+import Rel8.Schema.Kind ( Context )
 import Rel8.Schema.Null (Sql)
 import Rel8.Schema.Spec.ConstrainDBType ( ConstrainDBType )
 import Rel8.Table ( Table, Columns, toColumns )
@@ -58,7 +59,7 @@ class EqTable a => OrdTable a where
 
 
 instance
-  ( Table Expr (t Expr)
+  ( Table Expr (t (Expr :: Context))
   , f ~ Expr
   , HConstrainTable (Columns (t Expr)) (ConstrainDBType DBEq)
   , HConstrainTable (Columns (t Expr)) (ConstrainDBType DBOrd)

--- a/src/Rel8/Table/Recontextualize.hs
+++ b/src/Rel8/Table/Recontextualize.hs
@@ -22,6 +22,7 @@ import Rel8.Schema.Context.Label ( Labelable )
 import Rel8.Schema.HTable ( HTable )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Null ( Sql )
+import Rel8.Schema.Result ( Result )
 import Rel8.Table ( Table, Congruent )
 import Rel8.Type ( DBType )
 
@@ -41,7 +42,7 @@ class
     , b from -> a
 
 
-instance Sql DBType a => Recontextualize Identity Identity (Identity a) (Identity a)
+instance Sql DBType a => Recontextualize Result Result (Identity a) (Identity a)
 
 
 instance HTable t => Recontextualize from to (t (Col from)) (t (Col to))

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,7 +27,6 @@ import Control.Monad (void)
 import Control.Monad.IO.Class ( MonadIO, liftIO )
 import Data.Bifunctor ( bimap )
 import Data.Foldable ( for_ )
-import Data.Functor.Identity ( Identity )
 import Data.Int ( Int32, Int64 )
 import Data.List ( nub, sort )
 import Data.Maybe ( catMaybes )
@@ -60,6 +59,7 @@ import Control.Exception.Lifted ( bracket, throwIO, bracket_ )
 import Control.Monad.Trans.Control ( MonadBaseControl )
 
 -- rel8
+import Rel8 ( Result )
 import qualified Rel8
 
 -- scientific
@@ -161,9 +161,9 @@ data TestTable f = TestTable
   deriving anyclass Rel8.Rel8able
 
 
-deriving stock instance Eq (TestTable Identity)
-deriving stock instance Ord (TestTable Identity)
-deriving stock instance Show (TestTable Identity)
+deriving stock instance Eq (TestTable Result)
+deriving stock instance Ord (TestTable Result)
+deriving stock instance Show (TestTable Result)
 
 
 testTableSchema :: Rel8.TableSchema (TestTable Rel8.Name)
@@ -543,9 +543,9 @@ data TwoTestTables f =
   deriving anyclass Rel8.Rel8able
 
 
-deriving stock instance Eq (TwoTestTables Identity)
-deriving stock instance Ord (TwoTestTables Identity)
-deriving stock instance Show (TwoTestTables Identity)
+deriving stock instance Eq (TwoTestTables Result)
+deriving stock instance Ord (TwoTestTables Result)
+deriving stock instance Show (TwoTestTables Result)
 
 
 testNestedTables :: IO TmpPostgres.DB -> TestTree
@@ -578,7 +578,7 @@ testMaybeTableApplicative = databasePropertyTest "MaybeTable (<*>)" \transaction
       (as, []) -> selected === (Nothing <$ as)
       (as, bs) -> sort selected === sort (Just <$> liftA2 (,) as bs)
   where
-    genRows :: PropertyT IO [TestTable Identity]
+    genRows :: PropertyT IO [TestTable Result]
     genRows = forAll do
       Gen.list (Range.linear 0 10) $ liftA2 TestTable (Gen.text (Range.linear 0 10) Gen.unicode) (pure True)
 
@@ -591,7 +591,7 @@ rollingBack connection =
     (liftIO (run (sql "ROLLBACK") connection))
 
 
-genTestTable :: Gen (TestTable Identity)
+genTestTable :: Gen (TestTable Result)
 genTestTable = do
   testTableColumn1 <- Gen.text (Range.linear 0 5) Gen.alphaNum
   testTableColumn2 <- Gen.bool
@@ -673,9 +673,9 @@ newtype HKNestedPair f = HKNestedPair { pairOne :: (TestTable f, TestTable f) }
   deriving stock Generic
   deriving anyclass Rel8.Rel8able
 
-deriving stock instance Eq (HKNestedPair Identity)
-deriving stock instance Ord (HKNestedPair Identity)
-deriving stock instance Show (HKNestedPair Identity)
+deriving stock instance Eq (HKNestedPair Result)
+deriving stock instance Ord (HKNestedPair Result)
+deriving stock instance Show (HKNestedPair Result)
 
 
 testSelectNestedPairs :: IO TmpPostgres.DB -> TestTree
@@ -708,9 +708,9 @@ data NestedMaybeTable f = NestedMaybeTable
   deriving anyclass Rel8.Rel8able
 
 
-deriving stock instance Eq (NestedMaybeTable Identity)
-deriving stock instance Ord (NestedMaybeTable Identity)
-deriving stock instance Show (NestedMaybeTable Identity)
+deriving stock instance Eq (NestedMaybeTable Result)
+deriving stock instance Ord (NestedMaybeTable Result)
+deriving stock instance Show (NestedMaybeTable Result)
 
 
 testNestedMaybeTable :: IO TmpPostgres.DB -> TestTree


### PR DESCRIPTION
Previous it was `((Type -> Type) -> Type) -> Constraint`. The problem is this clashes with things like `HKD` from `higgledy`. We can use GADTs and PolyKinds hacks to get around this while mostly retaining the same API. The only major difference is we use `Result` in places where we used `Identity` before.