### PR TITLE
Fix teletype backticks

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -196,7 +196,7 @@ To execute this ``Query``, we pass it to ``select``::
   >>> :t select c (each projectSchema)
   select c (each projectSchema) :: MonadIO m => m [Project Result]
 
-When we ``select`` things containing ``Expr``s, Rel8 builds a new response
+When we ``select`` things containing ``Expr``\s, Rel8 builds a new response
 table with the ``Result`` interpretation. This means you'll get back plain
 Haskell values. Studying ``projectAuthorId`` again, we have::
 


### PR DESCRIPTION
rst doesn't seem to like having non-whitespace following closing backticks. Without a space the teletype region runs on until the end of `Result`.

(Perhaps there's a better fix. I'm not familiar with rst.)