### PR TITLE
Rename where{,Not}Exists to present and absent respectively

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+# 1.1.0.0 (??)
+
+* Fixes a bug where cartesian products of queries using `catListTable`, `catNonEmptyTable`, `catList` and `catNonEmpty` would incorrectly be zipped instead.
+
+* Simplify `evaluate` to run directly inside the `Query` monad, rendering the `Evaluate` monad unnecessary.
+
+* Rename `whereExists` and `whereNotExists` to `present` and `absent` respectively.
+
 # 1.0.0.1 (2021-06-21)
 
 This release contains various fixes for documentation.

--- a/docs/concepts/queries.rst
+++ b/docs/concepts/queries.rst
@@ -138,20 +138,20 @@ a query. The above query could thus be written as::
 
 ``where_`` and ``filter`` allow you to filter rows based on an expression, but
 sometimes we want to filter based on another query. For this, Rel8 offers
-``whereExists`` and ``whereNotExists``. For example, if all blog posts have a
-list of tags, we could use ``whereExists`` to find all blog posts that have been
+``present`` and ``absent``. For example, if all blog posts have a
+list of tags, we could use ``present`` to find all blog posts that have been
 tagged as "Haskell"::
 
   blogPost <- each blogPostSchema
-  whereExists do
+  present do
     filter (("Haskell" ==.) . tagName) =<< tagFromBlogPost blogPost
 
-Notice that this example uses ``whereExists`` with a query that itself uses
-``filter``. For each blog post, ``whereExists`` causes that row to be selected
+Notice that this example uses ``present`` with a query that itself uses
+``filter``. For each blog post, ``present`` causes that row to be selected
 only if the associated query finds a tag for that blog post with the ``tagName``
 "Haskell".
 
-Like ``filter`` there is also a chaining variant of ``whereExists`` - ``with``.
+Like ``filter`` there is also a chaining variant of ``present`` - ``with``.
 We could rewrite the above query using ``with`` as::
 
   haskellBlogPost <-

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -178,8 +178,8 @@ module Rel8
     -- ** Filtering
   , filter
   , where_
-  , whereExists
-  , whereNotExists
+  , present
+  , absent
   , distinct
   , distinctOn
   , distinctOnBy

--- a/src/Rel8/Query/Exists.hs
+++ b/src/Rel8/Query/Exists.hs
@@ -2,8 +2,8 @@
 
 module Rel8.Query.Exists
   ( exists, inQuery
-  , whereExists, with, withBy
-  , whereNotExists, without, withoutBy
+  , present, with, withBy
+  , absent, without, withoutBy
   )
 where
 
@@ -25,7 +25,7 @@ import Rel8.Table.Maybe ( isJustTable )
 
 -- | Checks if a query returns at least one row.
 exists :: Query a -> Query (Expr Bool)
-exists = fmap isJustTable . optional . whereExists
+exists = fmap isJustTable . optional . present
 -- FIXME: change this when b7aacc07c6392654cae439fc3b997620c3aa7a87 makes it
 -- into a release of Opaleye
 
@@ -34,23 +34,23 @@ inQuery :: EqTable a => a -> Query a -> Query (Expr Bool)
 inQuery a = exists . (>>= filter (a ==:))
 
 
--- | Produce the empty query if the given query returns no rows. @whereExists@
+-- | Produce the empty query if the given query returns no rows. @present@
 -- is equivalent to @WHERE EXISTS@ in SQL.
-whereExists :: Query a -> Query ()
-whereExists = mapOpaleye Opaleye.restrictExists
+present :: Query a -> Query ()
+present = mapOpaleye Opaleye.restrictExists
 
 
--- | Produce the empty query if the given query returns rows. @whereNotExists@
+-- | Produce the empty query if the given query returns rows. @absent@
 -- is equivalent to @WHERE NOT EXISTS@ in SQL.
-whereNotExists :: Query a -> Query ()
-whereNotExists = mapOpaleye Opaleye.restrictNotExists
+absent :: Query a -> Query ()
+absent = mapOpaleye Opaleye.restrictNotExists
 
 
 -- | @with@ is similar to 'filter', but allows the predicate to be a full query.
 --
--- @with f a = a <$ whereExists (f a)@, but this form matches 'filter'.
+-- @with f a = a <$ present (f a)@, but this form matches 'filter'.
 with :: (a -> Query b) -> a -> Query a
-with f a = a <$ whereExists (f a)
+with f a = a <$ present (f a)
 
 
 -- | Like @with@, but with a custom membership test.
@@ -60,7 +60,7 @@ withBy predicate bs = with $ \a -> bs >>= filter (predicate a)
 
 -- | Filter rows where @a -> Query b@ yields no rows.
 without :: (a -> Query b) -> a -> Query a
-without f a = a <$ whereNotExists (f a)
+without f a = a <$ absent (f a)
 
 
 -- | Like @without@, but with a custom membership test.


### PR DESCRIPTION
Should I add back the old ones with a deprecation warning, or can we get away with this?