### PR TITLE
Add Projection with machinery for generic construction

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -23,6 +23,7 @@ library
     , base ^>= 4.14 || ^>=4.15
     , bytestring
     , case-insensitive
+    , categories
     , comonad
     , contravariant
     , hasql ^>= 1.4.5.1
@@ -54,6 +55,8 @@ library
 
   other-modules:
     Rel8.Aggregate
+
+    Rel8.Category.Projection
 
     Rel8.Column
     Rel8.Column.ADT
@@ -87,6 +90,7 @@ library
     Rel8.Generic.Construction.ADT
     Rel8.Generic.Construction.Record
     Rel8.Generic.Map
+    Rel8.Generic.Projection
     Rel8.Generic.Record
     Rel8.Generic.Rel8able
     Rel8.Generic.Table

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -169,6 +169,10 @@ module Rel8
   , nullaryFunction
   , binaryOperator
 
+    -- ** Projection
+  , Projection
+  , project
+
     -- * Queries
   , Query
   , showQuery
@@ -278,6 +282,7 @@ import Prelude ()
 
 -- rel8
 import Rel8.Aggregate
+import Rel8.Category.Projection
 import Rel8.Column
 import Rel8.Column.ADT
 import Rel8.Column.Either
@@ -298,6 +303,7 @@ import Rel8.Expr.Ord
 import Rel8.Expr.Order
 import Rel8.Expr.Serialize
 import Rel8.Expr.Sequence
+import Rel8.Generic.Projection ()
 import Rel8.Generic.Rel8able ( KRel8able, Rel8able )
 import Rel8.Order
 import Rel8.Query

--- a/src/Rel8/Category/Projection.hs
+++ b/src/Rel8/Category/Projection.hs
@@ -1,0 +1,353 @@
+{-# language DataKinds #-}
+{-# language MultiParamTypeClasses #-}
+{-# language RankNTypes #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeFamilies #-}
+{-# language TypeOperators #-}
+{-# language UndecidableInstances #-}
+
+module Rel8.Category.Projection
+  ( Projection( Projection )
+  , project
+  )
+where
+
+-- base
+import Control.Category ( Category, (.), id )
+import Data.Kind ( Type )
+import GHC.TypeLits ( ErrorMessage( (:$$:), Text ), TypeError )
+import Prelude hiding ( Functor, (.), fmap, fst, id, product, snd )
+
+-- categories
+import Control.Categorical.Functor ( Endofunctor, Functor, fmap )
+import Control.Categorical.Bifunctor
+  ( Bifunctor, bimap
+  , PFunctor, first
+  , QFunctor, second
+  )
+import Control.Category.Associative ( Associative, associate, disassociate )
+import Control.Category.Braided ( Braided, braid, Symmetric )
+import Control.Category.Cartesian ( Cartesian, Product, (&&&), diag, fst, snd )
+import Control.Category.Monoidal ( Monoidal, Id, idl, idr, coidl, coidr )
+
+-- rel8
+import Rel8.Schema.HTable.Label ( hlabel, hrelabel, hunlabel )
+import qualified Rel8.Schema.HTable.Label as Label ( hproject )
+import Rel8.Schema.HTable.Product ( HProduct( HProduct ) )
+import Rel8.Table ( Table, Columns, fromColumns, toColumns )
+
+-- semigroupoids
+import Data.Semigroupoid ( Semigroupoid, o )
+
+
+-- | The category of 'Projection's. A @'Projection' a b@ differs from a
+-- function @a -> b@ in that the @b@ must be solely composed from the columns
+-- contained in @a@. 'Projection' has no 'const' or 'pure', so @b@ can never
+-- be just be a constant or literal value; it has to be projected from @a@.
+--
+-- You can use 'projection' to construct 'Projection's, and 'project' to
+-- \"run\" them.
+type Projection :: Type -> Type -> Type
+newtype Projection a b =
+  Projection (forall context. Columns a context -> Columns b context)
+
+
+instance Semigroupoid Projection where
+  Projection f `o` Projection g = Projection (f `o` g)
+
+
+instance Category Projection where
+  id = Projection id
+  (.) = o
+
+
+instance Cartesian Projection where
+  type Product Projection = (,)
+
+  fst = Projection $ \(HProduct a _) -> hunlabel a
+  snd = Projection $ \(HProduct _ b) -> hunlabel b
+  diag = Projection $ \a -> HProduct (hlabel a) (hlabel a)
+  Projection f &&& Projection g = Projection $ \a ->
+    case f a of
+      b -> case g a of
+        c -> HProduct (hlabel b) (hlabel c)
+
+
+instance Bifunctor (,) Projection Projection Projection where
+  bimap (Projection f) (Projection g) = Projection $ \(HProduct a c) ->
+    HProduct (Label.hproject f a) (Label.hproject g c)
+
+
+instance Associative Projection (,) where
+  associate = Projection $ \(HProduct ab c) -> case hunlabel ab of
+    HProduct a b -> HProduct a (hlabel (HProduct (hrelabel b) c))
+  disassociate = Projection $ \(HProduct a bc) -> case hunlabel bc of
+    HProduct b c -> HProduct (hlabel (HProduct a (hrelabel b))) c
+
+
+instance Braided Projection (,) where
+  braid = Projection $ \(HProduct a b) -> HProduct (hrelabel b) (hrelabel a)
+
+
+instance Symmetric Projection (,)
+
+
+instance PFunctor (,) Projection Projection where
+  first f = bimap f id
+
+
+instance QFunctor (,) Projection Projection where
+  second = bimap id
+
+
+instance Functor ((,) x) Projection Projection where
+  fmap = second
+
+
+instance Endofunctor ((,) x) Projection
+
+
+instance Bifunctor ((,,) x) Projection Projection Projection where
+  bimap (Projection f) (Projection g) = Projection $ \(HProduct x (HProduct a b)) ->
+    HProduct x (HProduct (Label.hproject f a) (Label.hproject g b))
+
+
+instance Associative Projection ((,,) x) where
+  associate = Projection $ \(HProduct x (HProduct x'ab c)) -> case hunlabel x'ab of
+    HProduct x' (HProduct a b) ->
+      HProduct x (HProduct a (hlabel (HProduct x' (HProduct (hrelabel b) c))))
+
+  disassociate = Projection $ \(HProduct x (HProduct a x'bc)) -> case hunlabel x'bc of
+    HProduct x' (HProduct b c) ->
+      HProduct x (HProduct (hlabel (HProduct x' (HProduct a (hrelabel b)))) c)
+
+
+instance Braided Projection ((,,) x) where
+  braid = Projection $ \(HProduct x (HProduct a b)) ->
+    HProduct x (HProduct (hrelabel b) (hrelabel a))
+
+
+instance Symmetric Projection ((,,) x)
+
+
+instance PFunctor ((,,) x) Projection Projection where
+  first f = bimap f id
+
+
+instance QFunctor ((,,) x) Projection Projection where
+  second = bimap id
+
+
+instance Functor ((,,) x y) Projection Projection where
+  fmap = second
+
+
+instance Endofunctor ((,,) x y) Projection
+
+
+instance Bifunctor ((,,,) x y) Projection Projection Projection where
+  bimap (Projection f) (Projection g) = Projection $ \(HProduct xy (HProduct a b)) ->
+    HProduct xy (HProduct (Label.hproject f a) (Label.hproject g b))
+
+
+instance Associative Projection ((,,,) x y) where
+  associate = Projection $ \(HProduct xy (HProduct x'y'ab c)) -> case hunlabel x'y'ab of
+    HProduct x'y' (HProduct a b) ->
+      HProduct xy (HProduct a (hlabel (HProduct x'y' (HProduct (hrelabel b) c))))
+
+  disassociate = Projection $ \(HProduct xy (HProduct a x'y'bc)) -> case hunlabel x'y'bc of
+    HProduct x'y' (HProduct b c) ->
+      HProduct xy (HProduct (hlabel (HProduct x'y' (HProduct a (hrelabel b)))) c)
+
+
+instance Braided Projection ((,,,) x y) where
+  braid = Projection $ \(HProduct xy (HProduct a b)) ->
+    HProduct xy (HProduct (hrelabel b) (hrelabel a))
+
+
+instance Symmetric Projection ((,,,) x y)
+
+
+instance PFunctor ((,,,) x y) Projection Projection where
+  first f = bimap f id
+
+
+instance QFunctor ((,,,) x y) Projection Projection where
+  second = bimap id
+
+
+instance Functor ((,,,) x y z) Projection Projection where
+  fmap = second
+
+
+instance Endofunctor ((,,,) x y z) Projection
+
+
+instance Bifunctor ((,,,,) x y z) Projection Projection Projection where
+  bimap (Projection f) (Projection g) = Projection $
+    \(HProduct xy (HProduct z (HProduct a b))) ->
+      HProduct xy $ HProduct z $
+        HProduct (Label.hproject f a) (Label.hproject g b)
+
+
+instance Associative Projection ((,,,,) x y z) where
+  associate = Projection $
+    \(HProduct xy (HProduct z (HProduct x'y'z'ab c))) ->
+      case hunlabel x'y'z'ab of
+        HProduct x'y' (HProduct z' (HProduct a b)) ->
+          HProduct xy $ HProduct z $ HProduct a $ hlabel $
+            HProduct x'y' $ HProduct z' $ HProduct (hrelabel b) c
+
+  disassociate = Projection $
+    \(HProduct xy (HProduct z (HProduct a x'y'z'bc))) ->
+      case hunlabel x'y'z'bc of
+        HProduct x'y' (HProduct z' (HProduct b c)) ->
+          HProduct xy $ HProduct z $
+            HProduct
+              (hlabel (HProduct x'y' (HProduct z' (HProduct a (hrelabel b)))))
+              c
+
+
+instance Braided Projection ((,,,,) x y z) where
+  braid = Projection $ \(HProduct xy (HProduct z (HProduct a b))) ->
+    HProduct xy (HProduct z (HProduct (hrelabel b) (hrelabel a)))
+
+
+instance Symmetric Projection ((,,,,) x y z)
+
+
+instance PFunctor ((,,,,) x y z) Projection Projection where
+  first f = bimap f id
+
+
+instance QFunctor ((,,,,) x y z) Projection Projection where
+  second = bimap id
+
+
+instance Functor ((,,,,) x y z w) Projection Projection where
+  fmap = second
+
+
+instance Endofunctor ((,,,,) x y z w) Projection
+
+
+instance Bifunctor ((,,,,,) x y z w) Projection Projection Projection where
+  bimap (Projection f) (Projection g) = Projection $
+    \(HProduct xyz (HProduct w (HProduct a b))) ->
+      HProduct xyz $ HProduct w $
+        HProduct (Label.hproject f a) (Label.hproject g b)
+
+
+instance Associative Projection ((,,,,,) x y z w) where
+  associate = Projection $
+    \(HProduct xyz (HProduct w (HProduct x'y'z'w'ab c))) ->
+      case hunlabel x'y'z'w'ab of
+        HProduct x'y'z' (HProduct w' (HProduct a b)) ->
+          HProduct xyz $ HProduct w $ HProduct a $ hlabel $
+            HProduct x'y'z' $ HProduct w' $ HProduct (hrelabel b) c
+
+  disassociate = Projection $
+    \(HProduct xyz (HProduct w (HProduct a x'y'z'w'bc))) ->
+      case hunlabel x'y'z'w'bc of
+        HProduct x'y'z' (HProduct w' (HProduct b c)) ->
+          HProduct xyz $ HProduct w $
+            HProduct
+              (hlabel (HProduct x'y'z' (HProduct w' (HProduct a (hrelabel b)))))
+              c
+
+
+instance Braided Projection ((,,,,,) x y z w) where
+  braid = Projection $ \(HProduct xyz (HProduct w (HProduct a b))) ->
+    HProduct xyz (HProduct w (HProduct (hrelabel b) (hrelabel a)))
+
+
+instance Symmetric Projection ((,,,,,) x y z w)
+
+
+instance PFunctor ((,,,,,) x y z w) Projection Projection where
+  first f = bimap f id
+
+
+instance QFunctor ((,,,,,) x y z w) Projection Projection where
+  second = bimap id
+
+
+instance Functor ((,,,,,) x y z w v) Projection Projection where
+  fmap = second
+
+
+instance Endofunctor ((,,,,,) x y z w v) Projection
+
+
+instance Bifunctor ((,,,,,,) x y z w v) Projection Projection Projection where
+  bimap (Projection f) (Projection g) = Projection $
+    \(HProduct xyz (HProduct wv (HProduct a b))) ->
+      HProduct xyz $ HProduct wv $
+        HProduct (Label.hproject f a) (Label.hproject g b)
+
+
+instance Associative Projection ((,,,,,,) x y z w v) where
+  associate = Projection $
+    \(HProduct xyz (HProduct wv (HProduct x'y'z'w'v'ab c))) ->
+      case hunlabel x'y'z'w'v'ab of
+        HProduct x'y'z' (HProduct w'v' (HProduct a b)) ->
+          HProduct xyz $ HProduct wv $ HProduct a $ hlabel $
+            HProduct x'y'z' $ HProduct w'v' $ HProduct (hrelabel b) c
+
+  disassociate = Projection $
+    \(HProduct xyz (HProduct wv (HProduct a x'y'z'w'v'bc))) ->
+      case hunlabel x'y'z'w'v'bc of
+        HProduct x'y'z' (HProduct w'v' (HProduct b c)) ->
+          HProduct xyz $ HProduct wv $
+            HProduct
+              (hlabel (HProduct x'y'z' (HProduct w'v' (HProduct a (hrelabel b)))))
+              c
+
+
+instance Braided Projection ((,,,,,,) x y z w v) where
+  braid = Projection $ \(HProduct xyz (HProduct wv (HProduct a b))) ->
+    HProduct xyz (HProduct wv (HProduct (hrelabel b) (hrelabel a)))
+
+
+instance Symmetric Projection ((,,,,,,) x y z w v)
+
+
+instance PFunctor ((,,,,,,) x y z w v) Projection Projection where
+  first f = bimap f id
+
+
+instance QFunctor ((,,,,,,) x y z w v) Projection Projection where
+  second = bimap id
+
+
+instance Functor ((,,,,,,) x y z w v u) Projection Projection where
+  fmap = second
+
+
+instance Endofunctor ((,,,,,,) x y z w v u) Projection
+
+
+-- | Turn a @'Projection' a b@ into a function @a -> b@.
+project :: forall a b context. (Table context a, Table context b)
+  => Projection a b -> a -> b
+project (Projection f) = fromColumns . f . toColumns
+
+
+-- | NOTE: Projection is not actually 'Monoidal', but categories got rid of
+-- @PreCartesian@, so we now need a 'Monoidal' instance to use 'Cartesian'
+instance Monoidal Projection (,) where
+  type Id Projection (,) = TypeError
+    ('Text "Projection is not actually Monoidal, but categories got rid of"
+     ':$$:
+     'Text "PreCartesian, so we need a Monoidal instance to use Cartesian")
+
+  idl = Projection $ \(HProduct _ b) -> hunlabel b
+  idr = Projection $ \(HProduct a _) -> hunlabel a
+  coidl = Projection $ \a -> HProduct (hlabel notMonoidal) (hlabel a)
+  coidr = Projection $ \a -> HProduct (hlabel a) (hlabel notMonoidal)
+
+
+notMonoidal :: a
+notMonoidal = error
+  "Projection is not actually Monoidal, but categories got rid of\
+  \ PreCartesian, so we now need a Monoidal instance to use Cartesian"

--- a/src/Rel8/Generic/Projection.hs
+++ b/src/Rel8/Generic/Projection.hs
@@ -1,0 +1,119 @@
+{-# language AllowAmbiguousTypes #-}
+{-# language DataKinds #-}
+{-# language FlexibleInstances #-}
+{-# language MultiParamTypeClasses #-}
+{-# language ScopedTypeVariables #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeApplications #-}
+{-# language TypeFamilies #-}
+{-# language TypeOperators #-}
+{-# language UndecidableInstances #-}
+
+{-# options_ghc -fno-warn-orphans #-}
+
+module Rel8.Generic.Projection
+  (
+  )
+where
+
+-- base
+import Data.Kind ( Constraint, Type )
+import GHC.Generics ( Rep, (:*:), K1, M1, Meta( MetaData, MetaSel ), C, D, S )
+import GHC.OverloadedLabels ( IsLabel, fromLabel )
+import GHC.TypeLits ( Symbol, TypeError, ErrorMessage( (:<>:), Text ) )
+import Prelude
+
+-- rel8
+import Rel8.Category.Projection ( Projection( Projection ) )
+import Rel8.Generic.Record ( Record )
+import Rel8.Generic.Table.Record ( GColumns )
+import Rel8.Schema.HTable.Label ( hunlabel )
+import Rel8.Schema.HTable.Product ( HProduct( HProduct ) )
+import Rel8.Table ( Columns, Table, TColumns )
+
+
+type GField :: Symbol -> (Type -> Type) -> Type
+type family GField name rep where
+  GField name (M1 D ('MetaData datatype _ _ _) rep) =
+    GField' name rep (TypeError (NoSelector datatype name))
+
+
+type GField' :: Symbol -> (Type -> Type) -> Type -> Type
+type family GField' name rep fallback where
+  GField' name (M1 C _ rep) fallback = GField' name rep fallback
+  GField' name (a :*: b) fallback = GField' name a (GField' name b fallback)
+  GField' name (M1 S ('MetaSel ('Just name) _ _ _) (K1 _ a)) _ = a
+  GField' _ _ fallback = fallback
+
+
+type NoSelector :: Symbol -> Symbol -> ErrorMessage
+type NoSelector datatype selector =
+  ( 'Text "The type `" ':<>:
+    'Text datatype ':<>:
+    'Text "` has no field `" ':<>:
+    'Text selector ':<>:
+    'Text "`."
+  )
+
+
+type GProjection :: Symbol -> (Type -> Type) -> Constraint
+class GProjection name rep where
+  gprojection :: GColumns TColumns rep context -> Columns (GField name rep) context
+
+
+instance
+  ( GProjection' name rep fallback
+  , fallback ~ TypeError (NoSelector datatype name)
+  )
+  => GProjection name (M1 D ('MetaData datatype _m _p _nt) rep)
+ where
+  gprojection a = gprojection' @name @rep @fallback a fallback
+    where
+      fallback = error "gprojection: impossible!"
+
+
+type GProjection' :: Symbol -> (Type -> Type) -> Type -> Constraint
+class GProjection' name rep fallback where
+  gprojection' :: ()
+    => GColumns TColumns rep context
+    -> Columns fallback context
+    -> Columns (GField' name rep fallback) context
+
+
+instance GProjection' name rep fallback => GProjection' name (M1 C meta rep) fallback where
+  gprojection' = gprojection' @name @rep @fallback
+
+
+instance
+  ( GProjection' name a fallback'
+  , GProjection' name b fallback
+  , fallback' ~ GField' name b fallback
+  )
+  => GProjection' name (a :*: b) fallback
+ where
+  gprojection' (HProduct a b) fallback =
+    gprojection' @name @a @fallback' a $
+      gprojection' @name @b @fallback b fallback
+
+
+instance Table context a =>
+  GProjection' name (M1 S ('MetaSel ('Just name) _su _ss _ds) (K1 i a)) fallback
+ where
+  gprojection' a _ = hunlabel a
+
+
+instance {-# OVERLAPPABLE #-} GField' name rep fallback ~ fallback =>
+  GProjection' name rep fallback
+ where
+  gprojection' _ = id
+
+
+instance
+  ( rep ~ Rep (Record a)
+  , Columns a ~ GColumns TColumns rep
+  , GProjection name rep
+  , b ~ GField name rep
+  )
+  => IsLabel name (Projection a b)
+ where
+  fromLabel = Projection $ gprojection @name @rep

--- a/src/Rel8/Schema/HTable/Label.hs
+++ b/src/Rel8/Schema/HTable/Label.hs
@@ -1,4 +1,5 @@
 {-# language DataKinds #-}
+{-# language RankNTypes #-}
 {-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
@@ -7,6 +8,7 @@
 
 module Rel8.Schema.HTable.Label
   ( HLabel, hlabel, hrelabel, hunlabel
+  , hproject
   )
 where
 
@@ -18,6 +20,9 @@ import Prelude
 
 -- rel8
 import Rel8.Schema.HTable
+  ( HTable, HConstrainTable, HField
+  , hfield, htraverse, htabulate, hspecs, hdicts
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Spec ( Spec, SSpec(..) )
 
@@ -57,3 +62,7 @@ hrelabel = hlabel . hunlabel
 hunlabel :: forall label t context. HLabel label t context -> t context
 hunlabel (HLabel a) = a
 {-# INLINABLE hunlabel #-}
+
+
+hproject :: (forall ctx. t ctx -> u ctx) -> HLabel label t context -> HLabel label u context
+hproject f (HLabel t) = HLabel (f t)

--- a/src/Rel8/Schema/HTable/MapTable.hs
+++ b/src/Rel8/Schema/HTable/MapTable.hs
@@ -6,7 +6,7 @@
 {-# language GADTs #-}
 {-# language InstanceSigs #-}
 {-# language MultiParamTypeClasses #-}
-{-# language PolyKinds #-}
+{-# language RankNTypes #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
@@ -19,11 +19,12 @@ module Rel8.Schema.HTable.MapTable
   , MapSpec(..)
   , Precompose(..)
   , HMapTableField(..)
+  , hproject
   )
 where
 
 -- base
-import Data.Kind ( Constraint, Type )
+import Data.Kind ( Constraint )
 import Prelude ( ($), (.), (<$>), fmap )
 
 -- rel8
@@ -34,19 +35,19 @@ import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Dict ( Dict( Dict ) )
 
 
-type HMapTable :: (a -> Exp b) -> ((a -> Type) -> Type) -> (b -> Type) -> Type
-newtype HMapTable f t g = HMapTable
-  { unHMapTable :: t (Precompose f g)
+type HMapTable :: (Spec -> Exp Spec) -> K.HTable -> K.HTable
+newtype HMapTable f t context = HMapTable
+  { unHMapTable :: t (Precompose f context)
   }
 
 
-type Precompose :: (a -> Exp b) -> (b -> Type) -> a -> Type
+type Precompose :: (Spec -> Exp Spec) -> K.Context -> K.Context
 newtype Precompose f g x = Precompose
   { precomposed :: g (Eval (f x))
   }
 
 
-type HMapTableField :: (Spec -> Exp a) -> K.HTable -> a -> Type
+type HMapTableField :: (Spec -> Exp Spec) -> K.HTable -> K.Context
 data HMapTableField f t x where
   HMapTableField :: HField t a -> HMapTableField f t (Eval (f a))
 
@@ -84,6 +85,10 @@ class MapSpec f where
   mapInfo :: SSpec x -> SSpec (Eval (f x))
 
 
-type ComposeConstraint :: (a -> Exp b) -> (b -> Constraint) -> a -> Constraint
+type ComposeConstraint :: (Spec -> Exp Spec) -> (Spec -> Constraint) -> Spec -> Constraint
 class c (Eval (f a)) => ComposeConstraint f c a
 instance c (Eval (f a)) => ComposeConstraint f c a
+
+
+hproject :: (forall ctx. t ctx -> u ctx) -> HMapTable f t context -> HMapTable f u context
+hproject f (HMapTable t) = HMapTable (f t)

--- a/src/Rel8/Schema/HTable/Nullify.hs
+++ b/src/Rel8/Schema/HTable/Nullify.hs
@@ -23,6 +23,7 @@ module Rel8.Schema.HTable.Nullify
   , hnulls
   , hnullify
   , hunnullify
+  , hproject
   )
 where
 
@@ -37,6 +38,7 @@ import Rel8.Schema.HTable.MapTable
   ( HMapTable, HMapTableField( HMapTableField )
   , MapSpec, mapInfo
   )
+import qualified Rel8.Schema.HTable.MapTable as HMapTable
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
 import qualified Rel8.Schema.Null as Type ( Nullify )
@@ -117,3 +119,7 @@ hunnullify unnullifier (HNullify as) =
     spec@SSpec {} -> case hfield as (HMapTableField field) of
       a -> unnullifier spec a
 {-# INLINABLE hunnullify #-}
+
+
+hproject :: (forall ctx. t ctx -> u ctx) -> HNullify t context -> HNullify u context
+hproject f (HNullify t) = HNullify (HMapTable.hproject f t)

--- a/src/Rel8/Schema/HTable/Vectorize.hs
+++ b/src/Rel8/Schema/HTable/Vectorize.hs
@@ -10,6 +10,7 @@
 {-# language LambdaCase #-}
 {-# language MultiParamTypeClasses #-}
 {-# language NamedFieldPuns #-}
+{-# language QuantifiedConstraints #-}
 {-# language RankNTypes #-}
 {-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
@@ -22,21 +23,26 @@ module Rel8.Schema.HTable.Vectorize
   ( HVectorize
   , hvectorize, hunvectorize
   , happend, hempty
+  , hproject
   )
 where
 
 -- base
 import Data.Kind ( Type )
 import Data.List.NonEmpty ( NonEmpty )
+import GHC.Generics ( Generic )
 import Prelude
 
 -- rel8
+import Rel8.FCF ( Eval, Exp )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.HTable
-  ( HTable
-  , hfield, htabulate, htabulateA, hspecs
+import Rel8.Schema.HTable ( HTable, hfield, htabulate, htabulateA, hspecs )
+import Rel8.Schema.HTable.MapTable
+  ( HMapTable, HMapTableField( HMapTableField )
+  , MapSpec, mapInfo
   )
+import qualified Rel8.Schema.HTable.MapTable as HMapTable
 import Rel8.Schema.Null ( Unnullify, NotNull, Nullity( NotNull ) )
 import Rel8.Schema.Spec ( Spec( Spec ), SSpec(..) )
 import Rel8.Type.Array ( listTypeInformation, nonEmptyTypeInformation )
@@ -44,9 +50,6 @@ import Rel8.Type.Information ( TypeInformation )
 
 -- semialign
 import Data.Zip ( Unzip, Zip, Zippy(..) )
-import Rel8.FCF
-import Rel8.Schema.HTable.MapTable
-import GHC.Generics (Generic)
 
 
 class Vector list where
@@ -142,3 +145,7 @@ hempty :: HTable t =>
   -> HVectorize [] t context
 hempty empty = HVectorize $ htabulate $ \(HMapTableField field) -> case hfield hspecs field of
   SSpec {nullity, info} -> empty nullity info
+
+
+hproject :: (forall ctx. t ctx -> u ctx) -> HVectorize list t context -> HVectorize list u context
+hproject f (HVectorize t) = HVectorize (HMapTable.hproject f t)

--- a/src/Rel8/Table/List.hs
+++ b/src/Rel8/Table/List.hs
@@ -20,12 +20,20 @@ import Data.Functor.Identity ( Identity( Identity ) )
 import Data.Kind ( Type )
 import Prelude
 
+-- categories
+import qualified Control.Categorical.Functor as Cat
+
 -- rel8
+import Rel8.Category.Projection ( Projection( Projection ) )
 import Rel8.Expr ( Expr( E, unE ) )
 import Rel8.Expr.Array ( sappend, sempty, slistOf )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.HTable.List ( HListTable )
-import Rel8.Schema.HTable.Vectorize ( happend, hempty, hvectorize, hunvectorize )
+import Rel8.Schema.HTable.Vectorize
+  ( happend, hempty
+  , hvectorize, hunvectorize
+  , hproject
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name( N, Name ) )
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
@@ -50,6 +58,13 @@ import Rel8.Table.Serialize ( ToExprs )
 type ListTable :: K.Context -> Type -> Type
 newtype ListTable context a =
   ListTable (HListTable (Columns a) (Context a))
+
+
+instance Cat.Functor (ListTable context) Projection Projection where
+  fmap (Projection f) = Projection $ hproject f
+
+
+instance Cat.Endofunctor (ListTable context) Projection
 
 
 instance (Table context a, context ~ context') =>

--- a/src/Rel8/Table/NonEmpty.hs
+++ b/src/Rel8/Table/NonEmpty.hs
@@ -21,12 +21,20 @@ import Data.Kind ( Type )
 import Data.List.NonEmpty ( NonEmpty )
 import Prelude hiding ( id )
 
+-- categories
+import qualified Control.Categorical.Functor as Cat
+
 -- rel8
+import Rel8.Category.Projection ( Projection( Projection ) )
 import Rel8.Expr ( Expr( E, unE ) )
 import Rel8.Expr.Array ( sappend1, snonEmptyOf )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.HTable.NonEmpty ( HNonEmptyTable )
-import Rel8.Schema.HTable.Vectorize ( happend, hvectorize, hunvectorize )
+import Rel8.Schema.HTable.Vectorize
+  ( happend
+  , hvectorize, hunvectorize
+  , hproject
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name( N, Name ) )
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
@@ -48,6 +56,13 @@ import Rel8.Table.Serialize ( ToExprs )
 type NonEmptyTable :: K.Context -> Type -> Type
 newtype NonEmptyTable context a =
   NonEmptyTable (HNonEmptyTable (Columns a) (Context a))
+
+
+instance Cat.Functor (NonEmptyTable context) Projection Projection where
+  fmap (Projection f) = Projection $ hproject f
+
+
+instance Cat.Endofunctor (NonEmptyTable context) Projection
 
 
 instance (Table context a, context ~ context') =>

--- a/src/Rel8/Table/Nullify.hs
+++ b/src/Rel8/Table/Nullify.hs
@@ -21,11 +21,15 @@ import Data.Functor.Identity ( runIdentity )
 import Data.Kind ( Type )
 import Prelude
 
+-- categories
+import qualified Control.Categorical.Functor as Cat
+
 -- comonad
 import Control.Comonad ( Comonad, duplicate, extract, ComonadApply, (<@>) )
 
 -- rel8
 import Rel8.Aggregate ( Aggregate )
+import Rel8.Category.Projection ( Projection( Projection ) )
 import Rel8.Expr ( Expr )
 import Rel8.Kind.Context ( Reifiable, contextSing )
 import Rel8.Schema.Context.Nullify
@@ -39,7 +43,11 @@ import Rel8.Schema.Context.Nullify
   )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.HTable ( HTable )
-import Rel8.Schema.HTable.Nullify ( HNullify, hnulls, hnullify, hunnullify, hguard )
+import Rel8.Schema.HTable.Nullify
+  ( HNullify, hnulls, hnullify, hunnullify
+  , hguard
+  , hproject
+  )
 import qualified Rel8.Schema.Kind as K
 import qualified Rel8.Schema.Result as R
 import Rel8.Schema.Spec ( Spec( Spec ) )
@@ -61,6 +69,13 @@ type Nullify :: K.Context -> Type -> Type
 data Nullify context a
   = Table (Nullifiability context) a
   | Fields (NonNullifiability context) (HNullify (Columns a) (Context a))
+
+
+instance Cat.Functor (Nullify context) Projection Projection where
+  fmap (Projection f) = Projection $ hproject f
+
+
+instance Cat.Endofunctor (Nullify context) Projection
 
 
 instance Nullifiable context => Functor (Nullify context) where


### PR DESCRIPTION
This allows us to make Functors out of ListTable and NonEmptyTable, albeit in the category of projections, but this is still a useful feature.