### PR TITLE
Link directly to Haddock for >$<

### DIFF
--- a/src/Rel8/Order.hs
+++ b/src/Rel8/Order.hs
@@ -26,7 +26,7 @@ import qualified Opaleye.Internal.Order as Opaleye
 -- instances.
 --
 -- A common pattern is to use '<>' to combine multiple orderings in sequence,
--- and '>$<' (from 'Contravariant') to select individual columns.
+-- and 'Data.Functor.Contravariant.>$<' to select individual columns.
 type Order :: Type -> Type
 newtype Order a = Order (Opaleye.Order a)
   deriving newtype (Contravariant, Divisible, Decidable, Semigroup, Monoid)


### PR DESCRIPTION
Perhaps I have misunderstood your intention here, but wouldn't a direct link to the Haddock for `>$<` be better?