### PR TITLE
Drop some coverage conditions from tests

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -473,9 +473,6 @@ testDBEq getTestDatabase = testGroup "DBEq instances"
         [res] <- liftIO $ Rel8.select connection $ pure $ Rel8.litExpr x Rel8.==. Rel8.litExpr y
         res === (x == y)
 
-        cover 1 "Equal" $ x == y
-        cover 1 "Not Equal" $ x /= y
-
 
 testTableEquality :: IO TmpPostgres.DB -> TestTree
 testTableEquality = databasePropertyTest "TestTable equality" \transaction -> do
@@ -486,9 +483,6 @@ testTableEquality = databasePropertyTest "TestTable equality" \transaction -> do
        pure $ Rel8.lit x Rel8.==: Rel8.lit y
 
      eq === (x == y)
-
-     cover 1 "Equal" $ x == y
-     cover 1 "Not Equal" $ x /= y
 
 
 testFromString :: IO TmpPostgres.DB -> TestTree


### PR DESCRIPTION
These are just making tests flaky. For now, they are removed. In the
future we should make these tests more likely to have full coverage.

Fixes #86.