### PR TITLE
Allow arbitrary queries in INSERT, UPDATE and DELETE

### DIFF
--- a/docs/concepts/insert.rst
+++ b/docs/concepts/insert.rst
@@ -64,11 +64,11 @@ using ``insert``. ``Insert`` takes:
   The rows to insert. These are the same as ``into``, but in the ``Expr``
   context. You can construct rows from their individual fields::
 
-    rows = [ MyTable { myTableA = lit "A", myTableB = lit 42 }
+    rows = values [ MyTable { myTableA = lit "A", myTableB = lit 42 }
 
   or you can use ``lit`` on a table value in the ``Result`` context::
 
-    rows = [ lit MyTable { myTableA = "A", myTableB = 42 }
+    rows = values [ lit MyTable { myTableA = "A", myTableB = 42 }
 
 ``onConflict``
   What should happen if an insert clashes with rows that already exist. This
@@ -99,7 +99,7 @@ For example, if we are inserting orders, we might want the order ids returned::
 
   insert Insert
     { into = orderSchema
-    , rows = [ order ]
+    , rows = values [ order ]
     , onConflict = Abort
     , returning = Projection orderId
     }
@@ -119,7 +119,7 @@ construct the ``DEFAULT`` expression::
 
   insert Insert
     { into = orderSchema
-    , rows = [ Order { orderId = unsafeDefault, ... } ]
+    , rows = values [ Order { orderId = unsafeDefault, ... } ]
     , onConflict = Abort
     , returning = Projection orderId
     }
@@ -148,7 +148,7 @@ them in Rel8, rather than in your database schema.
 
      insert Insert
        { into = orderSchema
-       , rows = [ Order { orderId = nextval "order_id_seq", ... } ]
+       , rows = values [ Order { orderId = nextval "order_id_seq", ... } ]
        , onConflict = Abort
        , returning = Projection orderId
        }

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -27,6 +27,7 @@ library
     , contravariant
     , hasql ^>= 1.4.5.1
     , opaleye ^>= 0.7.3.0
+    , pretty
     , profunctors
     , scientific
     , semialign
@@ -140,8 +141,10 @@ library
     Rel8.Statement.Insert
     Rel8.Statement.Returning
     Rel8.Statement.Select
+    Rel8.Statement.SQL
     Rel8.Statement.Update
     Rel8.Statement.View
+    Rel8.Statement.Where
 
     Rel8.Table
     Rel8.Table.ADT

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -260,14 +260,19 @@ module Rel8
   , OnConflict(..)
   , insert
   , unsafeDefault
+  , showInsert
 
     -- ** @DELETE@
   , Delete(..)
   , delete
+  , showDelete
 
     -- ** @UPDATE@
   , Update(..)
+  , Set
+  , Where
   , update
+  , showUpdate
 
     -- ** @.. RETURNING@
   , Returning(..)
@@ -334,8 +339,10 @@ import Rel8.Statement.Delete
 import Rel8.Statement.Insert
 import Rel8.Statement.Returning
 import Rel8.Statement.Select
+import Rel8.Statement.SQL
 import Rel8.Statement.Update
 import Rel8.Statement.View
+import Rel8.Statement.Where
 import Rel8.Table
 import Rel8.Table.ADT
 import Rel8.Table.Aggregate

--- a/src/Rel8/Query/SQL.hs
+++ b/src/Rel8/Query/SQL.hs
@@ -1,75 +1,21 @@
 {-# language FlexibleContexts #-}
-{-# language TypeFamilies #-}
-{-# language ViewPatterns #-}
+{-# language MonoLocalBinds #-}
 
 module Rel8.Query.SQL
   ( showQuery
-  , sqlForQuery, sqlForQueryWithNames
   )
 where
 
 -- base
-import Data.Foldable ( fold )
-import Data.Functor.Const ( Const( Const ), getConst )
-import Data.Void ( Void )
 import Prelude
-
--- opaleye
-import qualified Opaleye.Internal.HaskellDB.Sql as Opaleye
-import qualified Opaleye.Internal.PrimQuery as Opaleye
-import qualified Opaleye.Internal.Print as Opaleye
-import qualified Opaleye.Internal.Optimize as Opaleye
-import qualified Opaleye.Internal.QueryArr as Opaleye hiding ( Select )
-import qualified Opaleye.Internal.Sql as Opaleye
 
 -- rel8
 import Rel8.Expr ( Expr )
-import Rel8.Expr.Opaleye ( toPrimExpr )
 import Rel8.Query ( Query )
-import Rel8.Query.Opaleye ( toOpaleye )
-import Rel8.Schema.Name ( Name( Name ), Selects )
-import Rel8.Schema.HTable ( htabulateA, hfield )
-import Rel8.Table ( Table, toColumns )
-import Rel8.Table.Cols ( toCols )
-import Rel8.Table.Name ( namesFromLabels )
-import Rel8.Table.Opaleye ( castTable )
+import Rel8.Statement.Select ( ppSelect )
+import Rel8.Table ( Table )
 
 
--- | Convert a query to a 'String' containing the query as a @SELECT@
--- statement.
+-- | Convert a 'Query' to a 'String' containing a @SELECT@ statement.
 showQuery :: Table Expr a => Query a -> String
-showQuery = fold . sqlForQuery
-
-
-sqlForQuery :: Table Expr a
-  => Query a -> Maybe String
-sqlForQuery = sqlForQueryWithNames namesFromLabels . fmap toCols
-
-
-sqlForQueryWithNames :: Selects names exprs
-  => names -> Query exprs -> Maybe String
-sqlForQueryWithNames names query =
-  show . Opaleye.ppSql . selectFrom names exprs <$> optimize primQuery
-  where
-    (exprs, primQuery, _) =
-      Opaleye.runSimpleQueryArrStart (toOpaleye query) ()
-
-
-optimize :: Opaleye.PrimQuery' a -> Maybe (Opaleye.PrimQuery' Void)
-optimize = Opaleye.removeEmpty . Opaleye.optimize
-
-
-selectFrom :: Selects names exprs
-  => names -> exprs -> Opaleye.PrimQuery' Void -> Opaleye.Select
-selectFrom (toColumns -> names) (toColumns . castTable -> exprs) query =
-  Opaleye.SelectFrom $ Opaleye.newSelect
-    { Opaleye.attrs = Opaleye.SelectAttrs attributes
-    , Opaleye.tables = Opaleye.oneTable select
-    }
-  where
-    select = Opaleye.foldPrimQuery Opaleye.sqlQueryGenerator query
-    attributes = getConst $ htabulateA $ \field -> case hfield names field of
-      Name name -> case hfield exprs field of
-        expr -> Const (pure (makeAttr name (toPrimExpr expr)))
-    makeAttr label expr =
-      (Opaleye.sqlExpr expr, Just (Opaleye.SqlColumn label))
+showQuery = foldMap show . ppSelect

--- a/src/Rel8/Schema/Name.hs
+++ b/src/Rel8/Schema/Name.hs
@@ -13,6 +13,7 @@
 module Rel8.Schema.Name
   ( Name(..)
   , Selects
+  , ppColumn
   )
 where
 
@@ -21,6 +22,13 @@ import Data.Functor.Identity ( Identity( Identity ) )
 import Data.Kind ( Constraint, Type )
 import Data.String ( IsString )
 import Prelude
+
+-- opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql as Opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql.Print as Opaleye
+
+-- pretty
+import Text.PrettyPrint ( Doc )
 
 -- rel8
 import Rel8.Expr ( Expr )
@@ -63,3 +71,7 @@ instance Sql DBType a => Table Name (Name a) where
 type Selects :: Type -> Type -> Constraint
 class Transposes Name Expr names exprs => Selects names exprs
 instance Transposes Name Expr names exprs => Selects names exprs
+
+
+ppColumn :: String -> Doc
+ppColumn = Opaleye.ppSqlExpr . Opaleye.ColumnSqlExpr . Opaleye.SqlColumn

--- a/src/Rel8/Schema/Table.hs
+++ b/src/Rel8/Schema/Table.hs
@@ -1,13 +1,23 @@
 {-# language DeriveFunctor #-}
 {-# language DerivingStrategies #-}
+{-# language DisambiguateRecordFields #-}
+{-# language NamedFieldPuns #-}
 
 module Rel8.Schema.Table
   ( TableSchema(..)
+  , ppTable
   )
 where
 
 -- base
 import Prelude
+
+-- opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql as Opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql.Print as Opaleye
+
+-- pretty
+import Text.PrettyPrint ( Doc )
 
 
 -- | The schema for a table. This is used to specify the name and schema that a
@@ -27,3 +37,10 @@ data TableSchema names = TableSchema
     -- data type here, parameterized by the 'Rel8.ColumnSchema.ColumnSchema' functor.
   }
   deriving stock Functor
+
+
+ppTable :: TableSchema a -> Doc
+ppTable TableSchema {name, schema} = Opaleye.ppTable Opaleye.SqlTable
+  { sqlTableSchemaName = schema
+  , sqlTableName = name
+  }

--- a/src/Rel8/Statement/Delete.hs
+++ b/src/Rel8/Statement/Delete.hs
@@ -1,6 +1,7 @@
 {-# language DuplicateRecordFields #-}
 {-# language GADTs #-}
 {-# language NamedFieldPuns #-}
+{-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
@@ -8,6 +9,7 @@
 module Rel8.Statement.Delete
   ( Delete(..)
   , delete
+  , ppDelete
   )
 where
 
@@ -23,17 +25,14 @@ import qualified Hasql.Encoders as Hasql
 import qualified Hasql.Session as Hasql
 import qualified Hasql.Statement as Hasql
 
--- opaleye
-import qualified Opaleye.Internal.Manipulation as Opaleye
+-- pretty
+import Text.PrettyPrint ( Doc, (<+>), ($$), text )
 
 -- rel8
-import Rel8.Expr ( Expr )
-import Rel8.Expr.Opaleye ( toColumn, toPrimExpr )
 import Rel8.Schema.Name ( Selects )
-import Rel8.Schema.Table ( TableSchema )
-import Rel8.Statement.Returning ( Returning( NumberOfRowsAffected, Projection ) )
-import Rel8.Table.Cols ( fromCols, toCols )
-import Rel8.Table.Opaleye ( castTable, table, unpackspec )
+import Rel8.Schema.Table ( TableSchema, ppTable )
+import Rel8.Statement.Returning ( Returning(..), ppReturning )
+import Rel8.Statement.Where ( Where, ppWhere )
 import Rel8.Table.Serialize ( Serializable, parse )
 
 -- text
@@ -47,7 +46,7 @@ data Delete a where
   Delete :: Selects names exprs =>
     { from :: TableSchema names
       -- ^ Which table to delete from.
-    , deleteWhere :: exprs -> Expr Bool
+    , deleteWhere :: Where exprs
       -- ^ Which rows should be selected for deletion.
     , returning :: Returning names a
       -- ^ What to return from the @DELETE@ statement.
@@ -55,11 +54,22 @@ data Delete a where
     -> Delete a
 
 
+ppDelete :: Delete a -> Maybe Doc
+ppDelete Delete {..} = do
+  condition <- ppWhere from deleteWhere
+  pure $ text "DELETE FROM" <+> ppTable from
+    $$ condition
+    $$ ppReturning from returning
+
+
 -- | Run a @DELETE@ statement.
 delete :: Connection -> Delete a -> IO a
-delete c Delete {from, deleteWhere, returning} =
-  case returning of
-    NumberOfRowsAffected -> Hasql.run session c >>= either throwIO pure
+delete c d@Delete {returning} =
+  case (show <$> ppDelete d, returning) of
+    (Nothing, NumberOfRowsAffected) -> pure 0
+    (Nothing, Projection _) -> pure []
+    (Just sql, NumberOfRowsAffected) ->
+      Hasql.run session c >>= either throwIO pure
       where
         session = Hasql.statement () statement
         statement = Hasql.Statement bytes params decode prepare
@@ -67,12 +77,9 @@ delete c Delete {from, deleteWhere, returning} =
         params = Hasql.noParams
         decode = Hasql.rowsAffected
         prepare = False
-        sql = Opaleye.arrangeDeleteSql from' where'
-          where
-            from' = table $ toCols <$> from
-            where' = toColumn . toPrimExpr . deleteWhere . fromCols
 
-    Projection project -> Hasql.run session c >>= either throwIO pure
+    (Just sql, Projection project) ->
+      Hasql.run session c >>= either throwIO pure
       where
         session = Hasql.statement () statement
         statement = Hasql.Statement bytes params decode prepare
@@ -80,12 +87,6 @@ delete c Delete {from, deleteWhere, returning} =
         params = Hasql.noParams
         decode = decoder project
         prepare = False
-        sql =
-          Opaleye.arrangeDeleteReturningSql unpackspec from' where' project'
-          where
-            from' = table $ toCols <$> from
-            where' = toColumn . toPrimExpr . deleteWhere . fromCols
-            project' = castTable . toCols . project . fromCols
   where
     decoder :: forall exprs projection a. Serializable projection a
       => (exprs -> projection) -> Hasql.Result [a]

--- a/src/Rel8/Statement/Insert.hs
+++ b/src/Rel8/Statement/Insert.hs
@@ -1,20 +1,25 @@
 {-# language DuplicateRecordFields #-}
+{-# language FlexibleContexts #-}
 {-# language GADTs #-}
+{-# language LambdaCase #-}
 {-# language NamedFieldPuns #-}
+{-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 
 module Rel8.Statement.Insert
   ( Insert(..)
-  , OnConflict(..)
   , insert
+  , OnConflict(..)
+  , ppInsert
+  , ppInto
   )
 where
 
 -- base
 import Control.Exception ( throwIO )
-import Data.List.NonEmpty ( NonEmpty( (:|) ) )
+import Data.Foldable ( toList )
 import Data.Kind ( Type )
 import Prelude
 
@@ -26,15 +31,19 @@ import qualified Hasql.Session as Hasql
 import qualified Hasql.Statement as Hasql
 
 -- opaleye
-import qualified Opaleye.Internal.Manipulation as Opaleye
-import qualified Opaleye.Manipulation as Opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql.Print as Opaleye
+
+-- pretty
+import Text.PrettyPrint ( Doc, (<+>), ($$), parens, text )
 
 -- rel8
-import Rel8.Schema.Name ( Selects )
-import Rel8.Schema.Table ( TableSchema )
-import Rel8.Statement.Returning ( Returning( Projection, NumberOfRowsAffected ) )
-import Rel8.Table.Cols ( fromCols, toCols )
-import Rel8.Table.Opaleye ( castTable, table, unpackspec )
+import Rel8.Query ( Query )
+import Rel8.Schema.Name ( Name, Selects, ppColumn )
+import Rel8.Schema.Table ( TableSchema(..), ppTable )
+import Rel8.Statement.Returning ( Returning(..), ppReturning )
+import Rel8.Statement.Select ( ppSelect )
+import Rel8.Table ( Table )
+import Rel8.Table.Name ( showNames )
 import Rel8.Table.Serialize ( Serializable, parse )
 
 -- text
@@ -44,10 +53,18 @@ import Data.Text.Encoding ( encodeUtf8 )
 
 -- | @OnConflict@ allows you to add an @ON CONFLICT@ clause to an @INSERT@
 -- statement.
-type OnConflict :: Type
-data OnConflict
-  = Abort     -- ^ @ON CONFLICT ABORT@
-  | DoNothing -- ^ @ON CONFLICT DO NOTHING@
+type OnConflict :: Type -> Type
+data OnConflict names
+  = Abort
+  -- ^ @ON CONFLICT DO ABORT@
+  | DoNothing
+  -- ^ @ON CONFLICT DO UPDATE@
+
+
+ppOnConflict :: TableSchema names -> OnConflict names -> Doc
+ppOnConflict _schema = \case
+  Abort -> mempty
+  DoNothing -> text "ON CONFLICT DO NOTHING"
 
 
 -- | The constituent parts of a SQL @INSERT@ statement.
@@ -56,9 +73,10 @@ data Insert a where
   Insert :: Selects names exprs =>
     { into :: TableSchema names
       -- ^ Which table to insert into.
-    , rows :: [exprs]
-      -- ^ The rows to insert.
-    , onConflict :: OnConflict
+    , rows :: Query exprs
+      -- ^ The rows to insert. This can be an arbitrary query — use
+      -- 'Rel8.values' insert a static list of rows.
+    , onConflict :: OnConflict names
       -- ^ What to do if the inserted rows conflict with data already in the
       -- table.
     , returning :: Returning names a
@@ -67,14 +85,29 @@ data Insert a where
     -> Insert a
 
 
+ppInsert :: Insert a -> Maybe Doc
+ppInsert Insert {..} = do
+  rows' <- ppSelect rows
+  pure $ text "INSERT INTO" <+> ppInto into
+    $$ rows'
+    $$ ppOnConflict into onConflict
+    $$ ppReturning into returning
+
+
+ppInto :: Table Name a => TableSchema a -> Doc
+ppInto table@TableSchema {columns} =
+  ppTable table <+>
+  parens (Opaleye.commaV ppColumn (toList (showNames columns)))
+
+
 -- | Run an @INSERT@ statement
 insert :: Connection -> Insert a -> IO a
-insert c Insert {into, rows, onConflict, returning} =
-  case (rows, returning) of
-    ([], NumberOfRowsAffected) -> pure 0
-    ([], Projection _) -> pure []
+insert c i@Insert {returning} =
+  case (show <$> ppInsert i, returning) of
+    (Nothing, NumberOfRowsAffected) -> pure 0
+    (Nothing, Projection _) -> pure []
 
-    (x:xs, NumberOfRowsAffected) -> Hasql.run session c >>= either throwIO pure
+    (Just sql, NumberOfRowsAffected) -> Hasql.run session c >>= either throwIO pure
       where
         session = Hasql.statement () statement
         statement = Hasql.Statement bytes params decode prepare
@@ -82,12 +115,8 @@ insert c Insert {into, rows, onConflict, returning} =
         params = Hasql.noParams
         decode = Hasql.rowsAffected
         prepare = False
-        sql = Opaleye.arrangeInsertManySql into' rows' onConflict'
-          where
-            into' = table $ toCols <$> into
-            rows' = toCols <$> x :| xs
 
-    (x:xs, Projection project) -> Hasql.run session c >>= either throwIO pure
+    (Just sql, Projection project) -> Hasql.run session c >>= either throwIO pure
       where
         session = Hasql.statement () statement
         statement = Hasql.Statement bytes params decode prepare
@@ -95,24 +124,7 @@ insert c Insert {into, rows, onConflict, returning} =
         params = Hasql.noParams
         decode = decoder project
         prepare = False
-        sql =
-          Opaleye.arrangeInsertManyReturningSql
-            unpackspec
-            into'
-            rows'
-            project'
-            onConflict'
-          where
-            into' = table $ toCols <$> into
-            rows' = toCols <$> x :| xs
-            project' = castTable . toCols . project . fromCols
-
   where
-    onConflict' =
-      case onConflict of
-        DoNothing -> Just Opaleye.DoNothing
-        Abort     -> Nothing
-
     decoder :: forall exprs projection a. Serializable projection a
       => (exprs -> projection) -> Hasql.Result [a]
     decoder _ = Hasql.rowList (parse @projection @a)

--- a/src/Rel8/Statement/Returning.hs
+++ b/src/Rel8/Statement/Returning.hs
@@ -1,18 +1,31 @@
 {-# language GADTs #-}
+{-# language LambdaCase #-}
+{-# language NamedFieldPuns #-}
 {-# language StandaloneKindSignatures #-}
+{-# language StrictData #-}
 
 module Rel8.Statement.Returning
-  ( Returning(..)
+  ( Returning(..), ppReturning
   )
 where
 
 -- base
-import Data.Int ( Int64 )
+import Data.Foldable ( toList )
 import Data.Kind ( Type )
-import Prelude ()
+import Data.Int ( Int64 )
+import Prelude
+
+-- opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql.Print as Opaleye
+import qualified Opaleye.Internal.Sql as Opaleye
+
+-- pretty
+import Text.PrettyPrint ( Doc, (<+>), text )
 
 -- rel8
 import Rel8.Schema.Name ( Selects )
+import Rel8.Schema.Table ( TableSchema(..) )
+import Rel8.Table.Opaleye ( castTable, exprs, view )
 import Rel8.Table.Serialize ( Serializable )
 
 
@@ -27,3 +40,13 @@ data Returning names a where
   Projection :: (Selects names exprs, Serializable projection a)
     => (exprs -> projection)
     -> Returning names [a]
+
+
+ppReturning :: TableSchema names -> Returning names a -> Doc
+ppReturning TableSchema {columns} = \case
+  NumberOfRowsAffected -> mempty
+  Projection projection ->
+    text "RETURNING" <+> Opaleye.commaV Opaleye.ppSqlExpr (toList sqlExprs)
+    where
+      sqlExprs =
+        Opaleye.sqlExpr <$> exprs (castTable (projection (view columns)))

--- a/src/Rel8/Statement/SQL.hs
+++ b/src/Rel8/Statement/SQL.hs
@@ -1,0 +1,29 @@
+module Rel8.Statement.SQL
+  ( showDelete
+  , showInsert
+  , showUpdate
+  )
+where
+
+-- base
+import Prelude
+
+-- rel8
+import Rel8.Statement.Delete ( Delete, ppDelete )
+import Rel8.Statement.Insert ( Insert, ppInsert )
+import Rel8.Statement.Update ( Update, ppUpdate )
+
+
+-- | Convert a 'Delete' to a 'String' containing a @DELETE@ statement.
+showDelete :: Delete a -> String
+showDelete = foldMap show . ppDelete
+
+
+-- | Convert an 'Insert' to a 'String' containing an @INSERT@ statement.
+showInsert :: Insert a -> String
+showInsert = foldMap show . ppInsert
+
+
+-- | Convert an 'Update' to a 'String' containing an @UPDATE@ statement.
+showUpdate :: Update a -> String
+showUpdate = foldMap show . ppUpdate

--- a/src/Rel8/Statement/Select.hs
+++ b/src/Rel8/Statement/Select.hs
@@ -1,15 +1,17 @@
+{-# language FlexibleContexts #-}
 {-# language MonoLocalBinds #-}
 {-# language ScopedTypeVariables #-}
 {-# language TypeApplications #-}
 
 module Rel8.Statement.Select
   ( select
-  , selectWithNames
+  , ppSelect
   )
 where
 
 -- base
 import Control.Exception ( throwIO )
+import Data.Void ( Void )
 import Prelude
 
 -- hasql
@@ -19,10 +21,26 @@ import qualified Hasql.Encoders as Hasql
 import qualified Hasql.Session as Hasql
 import qualified Hasql.Statement as Hasql
 
+-- opaleye
+import qualified Opaleye.Internal.HaskellDB.Sql as Opaleye
+import qualified Opaleye.Internal.PrimQuery as Opaleye
+import qualified Opaleye.Internal.Print as Opaleye
+import qualified Opaleye.Internal.Optimize as Opaleye
+import qualified Opaleye.Internal.QueryArr as Opaleye hiding ( Select )
+import qualified Opaleye.Internal.Sql as Opaleye
+
+-- pretty
+import Text.PrettyPrint ( Doc )
+
 -- rel8
+import Rel8.Expr ( Expr )
 import Rel8.Query ( Query )
-import Rel8.Query.SQL ( sqlForQuery, sqlForQueryWithNames )
+import Rel8.Query.Opaleye ( toOpaleye )
 import Rel8.Schema.Name ( Selects )
+import Rel8.Table ( Table )
+import Rel8.Table.Cols ( toCols )
+import Rel8.Table.Name ( namesFromLabels )
+import Rel8.Table.Opaleye ( castTable, exprsWithNames )
 import Rel8.Table.Serialize ( Serializable, parse )
 
 -- text
@@ -33,9 +51,9 @@ import Data.Text.Encoding ( encodeUtf8 )
 -- | Run a @SELECT@ query, returning all rows.
 select :: forall exprs a. Serializable exprs a
   => Connection -> Query exprs -> IO [a]
-select c query = case sqlForQuery query of
+select c query = case ppSelect query of
   Nothing -> pure []
-  Just sql -> Hasql.run session c >>= either throwIO pure
+  Just doc -> Hasql.run session c >>= either throwIO pure
     where
       session = Hasql.statement () statement
       statement = Hasql.Statement bytes params decode prepare
@@ -43,20 +61,32 @@ select c query = case sqlForQuery query of
       params = Hasql.noParams
       decode = Hasql.rowList (parse @exprs @a)
       prepare = False
+      sql = show doc
 
 
-selectWithNames :: forall exprs a names.
-  ( Selects names exprs
-  , Serializable exprs a
-  )
-  => Connection -> names -> Query exprs -> IO [a]
-selectWithNames c names query = case sqlForQueryWithNames names query of
-  Nothing -> pure []
-  Just sql -> Hasql.run session c >>= either throwIO pure
-    where
-      session = Hasql.statement () statement
-      statement = Hasql.Statement bytes params decode prepare
-      bytes = encodeUtf8 (Text.pack sql)
-      params = Hasql.noParams
-      decode = Hasql.rowList (parse @exprs @a)
-      prepare = False
+ppSelect :: Table Expr exprs => Query exprs -> Maybe Doc
+ppSelect query =
+  Opaleye.ppSql . selectFrom namesFromLabels (toCols exprs) <$>
+    optimize primQuery
+  where
+    (exprs, primQuery, _) =
+      Opaleye.runSimpleQueryArrStart (toOpaleye query) ()
+
+
+optimize :: Opaleye.PrimQuery' a -> Maybe (Opaleye.PrimQuery' Void)
+optimize = Opaleye.removeEmpty . Opaleye.optimize
+
+
+selectFrom :: Selects names exprs
+  => names -> exprs -> Opaleye.PrimQuery' Void -> Opaleye.Select
+selectFrom names exprs query =
+  Opaleye.SelectFrom $ Opaleye.newSelect
+    { Opaleye.attrs = Opaleye.SelectAttrs attrs
+    , Opaleye.tables = Opaleye.oneTable table
+    }
+  where
+    table = Opaleye.foldPrimQuery Opaleye.sqlQueryGenerator query
+    attrs = makeAttr <$> exprsWithNames names (castTable exprs)
+      where
+        makeAttr (label, expr) =
+          (Opaleye.sqlExpr expr, Just (Opaleye.SqlColumn label))

--- a/src/Rel8/Statement/View.hs
+++ b/src/Rel8/Statement/View.hs
@@ -8,7 +8,6 @@ where
 
 -- base
 import Control.Exception ( throwIO )
-import Control.Monad ( (>=>) )
 import Data.Foldable ( fold )
 import Data.Maybe ( fromMaybe )
 import Prelude
@@ -22,10 +21,14 @@ import qualified Hasql.Statement as Hasql
 
 -- rel8
 import Rel8.Query ( Query )
-import Rel8.Query.SQL ( sqlForQueryWithNames )
 import Rel8.Schema.Name ( Selects )
-import Rel8.Schema.Table ( TableSchema( TableSchema ) )
+import Rel8.Schema.Table ( TableSchema )
+import Rel8.Statement.Insert ( ppInto )
+import Rel8.Statement.Select ( ppSelect )
 import Rel8.Table.Alternative ( emptyTable )
+
+-- pretty
+import Text.PrettyPrint ( Doc, (<+>), ($$), text )
 
 -- text
 import qualified Data.Text as Text
@@ -36,9 +39,9 @@ import Data.Text.Encoding ( encodeUtf8 )
 -- statement that will save the given query as a view. This can be useful if
 -- you want to share Rel8 queries with other applications.
 createView :: Selects names exprs
-  => TableSchema names -> Query exprs -> Connection -> IO ()
-createView (TableSchema name mschema names) query =
-  Hasql.run session >=> either throwIO pure
+  => Connection -> TableSchema names -> Query exprs -> IO ()
+createView c schema query =
+  Hasql.run session c >>= either throwIO pure
   where
     session = Hasql.statement () statement
     statement = Hasql.Statement bytes params decode prepare
@@ -46,18 +49,15 @@ createView (TableSchema name mschema names) query =
     params = Hasql.noParams
     decode = Hasql.noResult
     prepare = False
-    sql = "CREATE VIEW " <> title <> " AS " <> select
-      where
-        title = case mschema of
-          Nothing -> quote name
-          Just schema -> quote schema <> "." <> quote name
-    select = fromMaybe fallback $ sqlForQueryWithNames names query
-      where
-        fallback = fold $ sqlForQueryWithNames names emptyTable
+    sql = show (ppCreateView schema query)
 
 
-quote :: String -> String
-quote string = "\"" <> concatMap go string <> "\""
+ppCreateView :: Selects names exprs
+  => TableSchema names -> Query exprs -> Doc
+ppCreateView schema query =
+  text "CREATE VIEW" <+>
+  ppInto schema $$
+  text "AS" <+>
+  fromMaybe fallback (ppSelect query)
   where
-    go '"' = "\"\""
-    go c = [c]
+    fallback = fold (ppSelect (emptyTable `asTypeOf` query))

--- a/src/Rel8/Statement/Where.hs
+++ b/src/Rel8/Statement/Where.hs
@@ -1,0 +1,37 @@
+{-# language MonoLocalBinds #-}
+{-# language NamedFieldPuns #-}
+{-# language StrictData #-}
+
+module Rel8.Statement.Where
+  ( Where, ppWhere
+  )
+where
+
+-- base
+import Data.Functor ( (<&>) )
+import Prelude
+
+-- pretty
+import Text.PrettyPrint ( Doc, ($$), parens, text )
+
+-- rel8
+import Rel8.Expr.Bool ( true )
+import Rel8.Query ( Query )
+import Rel8.Schema.Name ( Selects )
+import Rel8.Schema.Table ( TableSchema(..) )
+import Rel8.Statement.Select ( ppSelect )
+import Rel8.Table.Opaleye ( view )
+
+
+-- | The @WHERE@ condition in a @DELETE@ or @UPDATE@ statement. This can be
+-- an arbitrary 'Query': if the query returns zero rows, then the condition
+-- is false, if the query returns one or more rows, then the condition is
+-- true. Most of the time you'll want to use 'Rel8.where_' to supply an
+-- explicit boolean value.
+type Where expr = expr -> Query ()
+
+
+ppWhere :: Selects names exprs => TableSchema names -> Where exprs -> Maybe Doc
+ppWhere TableSchema {columns} where_ =
+  ppSelect (true <$ where_ (view columns)) <&> \query ->
+    text "WHERE EXISTS" $$ parens query

--- a/src/Rel8/Table/Name.hs
+++ b/src/Rel8/Table/Name.hs
@@ -12,7 +12,6 @@
 module Rel8.Table.Name
   ( namesFromLabels
   , namesFromLabelsWith
-  , showExprs
   , showLabels
   , showNames
   )
@@ -25,17 +24,11 @@ import Data.List.NonEmpty ( NonEmpty, intersperse, nonEmpty )
 import Data.Maybe ( fromMaybe )
 import Prelude
 
--- opaleye
-import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
-
 -- rel8
-import Rel8.Expr ( Expr )
-import Rel8.Expr.Opaleye ( toPrimExpr )
 import Rel8.Schema.HTable ( htabulate, htabulateA, hfield, hspecs )
 import Rel8.Schema.Name ( Name( Name ) )
 import Rel8.Schema.Spec ( Spec(..) )
 import Rel8.Table ( Table(..) )
-import Rel8.Table.Cols ( Cols( Cols ) )
 
 
 -- | Construct a table in the 'Name' context containing the names of all
@@ -70,23 +63,16 @@ namesFromLabelsWith f = fromColumns $ htabulate $ \field ->
     Spec {labels} -> Name (f (renderLabels labels))
 
 
-showExprs :: Table Expr a => a -> [(String, Opaleye.PrimExpr)]
-showExprs as = case (namesFromLabels, toColumns as) of
-  (Cols names, exprs) -> getConst $ htabulateA $ \field ->
-    case (hfield names field, hfield exprs field) of
-      (Name name, expr) -> Const [(name, toPrimExpr expr)]
-
-
 showLabels :: forall a. Table (Context a) a => a -> [NonEmpty String]
 showLabels _ = getConst $
   htabulateA @(Columns a) $ \field -> case hfield hspecs field of
-    Spec {labels} -> Const [renderLabels labels]
+    Spec {labels} -> Const (pure (renderLabels labels))
 
 
-showNames :: forall a. Table Name a => a -> [String]
+showNames :: forall a. Table Name a => a -> NonEmpty String
 showNames (toColumns -> names) = getConst $
   htabulateA @(Columns a) $ \field -> case hfield names field of
-    Name name -> Const [name]
+    Name name -> Const (pure name)
 
 
 renderLabels :: [String] -> NonEmpty String

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -189,7 +189,7 @@ testSelectTestTable = databasePropertyTest "Can SELECT TestTable" \transaction -
       liftIO $ Rel8.insert connection
         Rel8.Insert
           { into = testTableSchema
-          , rows = map Rel8.lit rows
+          , rows = Rel8.values $ map Rel8.lit rows
           , onConflict = Rel8.DoNothing
           , returning = Rel8.NumberOfRowsAffected
           }
@@ -602,7 +602,7 @@ testUpdate = databasePropertyTest "Can UPDATE TestTable" \transaction -> do
     void $ liftIO $ Rel8.insert connection
       Rel8.Insert
         { into = testTableSchema
-        , rows = map Rel8.lit $ Map.keys rows
+        , rows = Rel8.values $ map Rel8.lit $ Map.keys rows
         , onConflict = Rel8.DoNothing
         , returning = Rel8.NumberOfRowsAffected
         }
@@ -624,7 +624,7 @@ testUpdate = databasePropertyTest "Can UPDATE TestTable" \transaction -> do
               )
               r
               updates
-        , updateWhere = \_ -> Rel8.lit True
+        , updateWhere = \_ -> Rel8.where_ $ Rel8.lit True
         , returning = Rel8.NumberOfRowsAffected
         }
 
@@ -646,7 +646,7 @@ testDelete = databasePropertyTest "Can DELETE TestTable" \transaction -> do
     void $ liftIO $ Rel8.insert connection
       Rel8.Insert
         { into = testTableSchema
-        , rows = map Rel8.lit rows
+        , rows = Rel8.values $ map Rel8.lit rows
         , onConflict = Rel8.DoNothing
         , returning = Rel8.NumberOfRowsAffected
         }
@@ -655,7 +655,7 @@ testDelete = databasePropertyTest "Can DELETE TestTable" \transaction -> do
       liftIO $ Rel8.delete connection
         Rel8.Delete
           { from = testTableSchema
-          , deleteWhere = testTableColumn2
+          , deleteWhere = Rel8.where_ <$> testTableColumn2
           , returning = Rel8.Projection id
           }
 


### PR DESCRIPTION
This PR makes several changes to our "manipulation" functions (`insert`, `update`, `delete`).

Firstly, we now allow the insertion of arbitrary queries (not just static `VALUES`). `values` recovers the old behaviour.

Secondly, the `WHERE` clauses of `UPDATE` and `DELETE` are now also arbitrary queries (allowing joining against other tables and the use of functions like `absent` and `present`). `where_` recovers the old behaviour.

In terms of generating the SQL to implement these features, it was unfortunately significantly less work to roll our own here than to add this upstream to Opaleye proper, because it would have required more refactoring than I felt comfortable doing.