### PR TITLE
Simplify Context to be `Type -> Type`

### DIFF
--- a/src/Rel8/Expr.hs
+++ b/src/Rel8/Expr.hs
@@ -56,9 +56,9 @@ import Rel8.Type.Semigroup ( DBSemigroup, (<>.) )
 
 -- | Typed SQL expressions.
 type role Expr representational
-type Expr :: k -> Type
+type Expr :: Type -> Type
 data Expr a where
-  Expr :: k ~ Type => !Opaleye.PrimExpr -> Expr (a :: k)
+  Expr :: !Opaleye.PrimExpr -> Expr a
 
 
 deriving stock instance Show (Expr a)

--- a/src/Rel8/Expr.hs-boot
+++ b/src/Rel8/Expr.hs-boot
@@ -17,6 +17,6 @@ import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
 
 
 type role Expr representational
-type Expr :: k -> Type
+type Expr :: Type -> Type
 data Expr a where
-  Expr :: k ~ Type => !Opaleye.PrimExpr -> Expr (a :: k)
+  Expr :: !Opaleye.PrimExpr -> Expr a

--- a/src/Rel8/Schema/Kind.hs
+++ b/src/Rel8/Schema/Kind.hs
@@ -22,11 +22,8 @@ type HTable :: Type
 type HTable = HContext -> Type
 
 
-data X
-
-
 type Context :: Type
-type Context = X -> Type
+type Context = Type -> Type
 
 
 type Rel8able :: Type

--- a/src/Rel8/Schema/Name.hs
+++ b/src/Rel8/Schema/Name.hs
@@ -52,7 +52,7 @@ data Name a where
 deriving stock instance Show (Name a)
 
 
-instance k ~ Type => IsString (Name (a :: k)) where
+instance IsString (Name a) where
   fromString = Name
 
 

--- a/src/Rel8/Schema/Name.hs
+++ b/src/Rel8/Schema/Name.hs
@@ -44,9 +44,9 @@ import Rel8.Type ( DBType )
 -- schema definition. You can construct names by using the @OverloadedStrings@
 -- extension and writing string literals. This is typically done when providing
 -- a 'TableSchema' value.
-type Name :: k -> Type
+type Name :: Type -> Type
 data Name a where
-  Name :: k ~ Type => !String -> Name (a :: k)
+  Name :: !String -> Name a
 
 
 deriving stock instance Show (Name a)


### PR DESCRIPTION
As far as I can tell, the special `X -> Type` trick doesn't seem to be necessary anymore.