### PR TITLE
Export `select`, `insert`, `update` and `delete` as `Hasql.Statement`s

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -16,6 +16,8 @@
   * `Table` has a new associated type - `FromExprs`. This was previously an open type family.
   * `Table` has a new associated type - `Transpose` - and `Recontextualise` has been renamed to `Transposes`. This `Transposes` class now operates in terms of `Transpose`.
 
+* `select`, `insert`, `update` and `delete` now produce Hasql `Statement`s, rather than actually running the statement as IO. This allows Rel8 to be used with transaction/connection-managing monads like [`hasql-transaction`](https://hackage.haskell.org/package/hasql-transaction). ([#94](https://github.com/circuithub/rel8/pull/94))
+
 ## New features
 
 * You can derive `Rel8able` for "vanilla" higher-kinded data types - data types that don't use the `Column` type family. For example, the following is now possible:

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -37,7 +37,6 @@ library
     , text
     , these
     , time
-    , transformers
     , uuid
   default-language:
     Haskell2010
@@ -201,9 +200,9 @@ test-suite tests
     , case-insensitive
     , containers
     , hasql
+    , hasql-transaction
     , hedgehog          ^>=1.0.2
-    , lifted-base       ^>=0.2.3.12
-    , monad-control     ^>=1.0.2.3
+    , mmorph
     , rel8
     , scientific
     , tasty
@@ -211,6 +210,7 @@ test-suite tests
     , text
     , time
     , tmp-postgres      ^>=1.34.1.0
+    , transformers
     , uuid
 
   other-modules:

--- a/src/Rel8/Query/SQL.hs
+++ b/src/Rel8/Query/SQL.hs
@@ -18,4 +18,4 @@ import Rel8.Table ( Table )
 
 -- | Convert a 'Query' to a 'String' containing a @SELECT@ statement.
 showQuery :: Table Expr a => Query a -> String
-showQuery = foldMap show . ppSelect
+showQuery = show . ppSelect

--- a/src/Rel8/Statement/Returning.hs
+++ b/src/Rel8/Statement/Returning.hs
@@ -9,9 +9,7 @@
 
 module Rel8.Statement.Returning
   ( Returning( NumberOfRowsAffected, Projection )
-
   , decodeReturning
-  , emptyReturning
   , ppReturning
   )
 where
@@ -124,11 +122,6 @@ decodeReturning :: Returning names a -> Hasql.Result a
 decodeReturning = runReturning
   (<$> Hasql.rowsAffected)
   (\decoder withRows -> withRows <$> Hasql.rowList decoder)
-
-
-emptyReturning :: Returning names a -> a
-emptyReturning =
-  runReturning (\withCount -> withCount 0) (\_ withRows -> withRows [])
 
 
 ppReturning :: TableSchema names -> Returning names a -> Doc

--- a/src/Rel8/Statement/SQL.hs
+++ b/src/Rel8/Statement/SQL.hs
@@ -16,14 +16,14 @@ import Rel8.Statement.Update ( Update, ppUpdate )
 
 -- | Convert a 'Delete' to a 'String' containing a @DELETE@ statement.
 showDelete :: Delete a -> String
-showDelete = foldMap show . ppDelete
+showDelete = show . ppDelete
 
 
 -- | Convert an 'Insert' to a 'String' containing an @INSERT@ statement.
 showInsert :: Insert a -> String
-showInsert = foldMap show . ppInsert
+showInsert = show . ppInsert
 
 
 -- | Convert an 'Update' to a 'String' containing an @UPDATE@ statement.
 showUpdate :: Update a -> String
-showUpdate = foldMap show . ppUpdate
+showUpdate = show . ppUpdate

--- a/src/Rel8/Statement/View.hs
+++ b/src/Rel8/Statement/View.hs
@@ -8,8 +8,6 @@ where
 
 -- base
 import Control.Exception ( throwIO )
-import Data.Foldable ( fold )
-import Data.Maybe ( fromMaybe )
 import Prelude
 
 -- hasql
@@ -25,7 +23,6 @@ import Rel8.Schema.Name ( Selects )
 import Rel8.Schema.Table ( TableSchema )
 import Rel8.Statement.Insert ( ppInto )
 import Rel8.Statement.Select ( ppSelect )
-import Rel8.Table.Alternative ( emptyTable )
 
 -- pretty
 import Text.PrettyPrint ( Doc, (<+>), ($$), text )
@@ -49,7 +46,8 @@ createView connection schema query =
     params = Hasql.noParams
     decode = Hasql.noResult
     prepare = False
-    sql = show (ppCreateView schema query)
+    sql = show doc
+    doc = ppCreateView schema query
 
 
 ppCreateView :: Selects names exprs
@@ -58,6 +56,4 @@ ppCreateView schema query =
   text "CREATE VIEW" <+>
   ppInto schema $$
   text "AS" <+>
-  fromMaybe fallback (ppSelect query)
-  where
-    fallback = fold (ppSelect (emptyTable `asTypeOf` query))
+  ppSelect query


### PR DESCRIPTION
Fixes #82 