### PR TITLE
Support GHC 9 and switch default compiler

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -14,6 +14,8 @@
 
 * Require Opaleye 0.7.3.0. This version has better support for lateral queries, which can improve query plans, especially in `optional`/`LEFT JOIN` ([#72](https://github.com/circuithub/rel8/pull/72))
 
+* Rel8 now compiles with GHC 9. ([#97](https://github.com/circuithub/rel8/pull/97))
+
 ## Other changes
 
 * `exists` is now implemented in terms of the SQL `EXISTS` keyword. ([#69](https://github.com/circuithub/rel8/pull/69))

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,15 @@
-let 
+let
   haskellNix = import (import ./nix/sources.nix)."haskell.nix" {};
 
   nixpkgsSrc = haskellNix.sources.nixpkgs-2009;
 
   nixpkgsArgs = haskellNix.nixpkgsArgs;
 
-  compiler-nix-name = "ghc8104";
+  compiler-nix-name = "ghc901";
 
   pkgs = import nixpkgsSrc nixpkgsArgs;
 
-in 
+in
 pkgs.haskell-nix.project {
   inherit compiler-nix-name;
 
@@ -20,7 +20,7 @@ pkgs.haskell-nix.project {
     src = ./.;
   };
 
-  modules = [ 
+  modules = [
     { packages.rel8 = {
         preCheck = ''
           export PATH="${pkgs.postgresql}/bin:${"$PATH"}"

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ let
 in
   hsPkgs.shellFor {
     withHoogle = false;
-    tools = { cabal = "latest"; haskell-language-server = "latest"; };
+    tools = { cabal = "latest"; };
     exactDeps = false;
     buildInputs = [ pkgs.postgresql pkgs.pythonPackages.sphinx ];
   }

--- a/src/Rel8/Generic/Table.hs
+++ b/src/Rel8/Generic/Table.hs
@@ -124,9 +124,9 @@ ggfromColumns :: forall algebra _Table _Columns rep context x.
   -> (forall a. Eval (_Table a) => Eval (_Columns a) context -> a)
   -> Eval (GGColumns algebra _Columns rep) context
   -> rep x
-ggfromColumns = case algebraSing @algebra of
-  SProduct -> \_ _ -> gfromColumns @_Table @_Columns
-  SSum -> gfromColumnsADT @_Table @_Columns
+ggfromColumns f g h x = case algebraSing @algebra of
+  SProduct -> gfromColumns @_Table @_Columns h x
+  SSum -> gfromColumnsADT @_Table @_Columns f g h x
 
 
 ggtoColumns :: forall algebra _Table _Columns rep context x.
@@ -138,9 +138,9 @@ ggtoColumns :: forall algebra _Table _Columns rep context x.
   -> (forall a. Eval (_Table a) => a -> Eval (_Columns a) context)
   -> rep x
   -> Eval (GGColumns algebra _Columns rep) context
-ggtoColumns = case algebraSing @algebra of
-  SProduct -> \_ _ -> gtoColumns @_Table @_Columns
-  SSum -> gtoColumnsADT @_Table @_Columns
+ggtoColumns f g h x = case algebraSing @algebra of
+  SProduct -> gtoColumns @_Table @_Columns h x
+  SSum -> gtoColumnsADT @_Table @_Columns f g h x
 
 
 ggtable :: forall algebra _Table _Columns rep context.
@@ -168,9 +168,9 @@ ggfromResult :: forall algebra _ToExprs _Columns exprs rep x.
       -> a)
   -> Eval (GGColumns algebra _Columns exprs) (Col Result)
   -> rep x
-ggfromResult = case algebraSing @algebra of
-  SProduct -> gfromResult @_ToExprs @_Columns @exprs
-  SSum -> gfromResultADT @_ToExprs @_Columns @exprs
+ggfromResult f x = case algebraSing @algebra of
+  SProduct -> gfromResult @_ToExprs @_Columns @exprs f x
+  SSum -> gfromResultADT @_ToExprs @_Columns @exprs f x
 
 
 ggtoResult :: forall algebra _ToExprs _Columns exprs rep x.
@@ -183,6 +183,6 @@ ggtoResult :: forall algebra _ToExprs _Columns exprs rep x.
       -> Eval (_Columns expr) (Col Result))
   -> rep x
   -> Eval (GGColumns algebra _Columns exprs) (Col Result)
-ggtoResult = case algebraSing @algebra of
-  SProduct -> gtoResult @_ToExprs @_Columns @exprs
-  SSum -> gtoResultADT @_ToExprs @_Columns @exprs
+ggtoResult f x = case algebraSing @algebra of
+  SProduct -> gtoResult @_ToExprs @_Columns @exprs f x
+  SSum -> gtoResultADT @_ToExprs @_Columns @exprs f x


### PR DESCRIPTION
This required some eta expansion in `Rel8.Generic.Table`, probably due to changes to simplified subsumption.