### PR TITLE
Move `Rel8.Generic.Rel8able.Test` to a test suite

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -88,7 +88,6 @@ library
     Rel8.Generic.Record
     Rel8.Generic.Reify
     Rel8.Generic.Rel8able
-    Rel8.Generic.Rel8able.Test
     Rel8.Generic.Table
     Rel8.Generic.Table.ADT
     Rel8.Generic.Table.Record
@@ -204,6 +203,9 @@ test-suite tests
     , time
     , tmp-postgres      ^>=1.34.1.0
     , uuid
+
+  other-modules:
+    Rel8.Generic.Rel8able.Test
 
   main-is:          Main.hs
   hs-source-dirs:   tests

--- a/tests/Rel8/Generic/Rel8able/Test.hs
+++ b/tests/Rel8/Generic/Rel8able/Test.hs
@@ -121,7 +121,7 @@ deriving via HKDT HKDSum
 data HKDTest f = HKDTest
   { s3Object :: Lift f S3Object
   , hkdSum :: Lift f HKDSum
-  } 
+  }
   deriving stock Generic
   deriving anyclass Rel8able
 


### PR DESCRIPTION
This module is pretty expensive to compile, but is really just a test. As such, this commit moves it from the main `library` component, and into our `test-suite` component.