### PR TITLE
Introduce Rel8.Table.Nullify

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -23,6 +23,7 @@ library
     , base ^>= 4.14 || ^>=4.15
     , bytestring
     , case-insensitive
+    , comonad
     , contravariant
     , hasql ^>= 1.4.5.1
     , opaleye ^>= 0.7.3.0
@@ -158,6 +159,7 @@ library
     Rel8.Table.Maybe
     Rel8.Table.Name
     Rel8.Table.NonEmpty
+    Rel8.Table.Nullify
     Rel8.Table.Opaleye
     Rel8.Table.Ord
     Rel8.Table.Order

--- a/src/Rel8/Generic/Construction.hs
+++ b/src/Rel8/Generic/Construction.hs
@@ -3,7 +3,6 @@
 {-# language DataKinds #-}
 {-# language FlexibleContexts #-}
 {-# language FlexibleInstances #-}
-{-# language LambdaCase #-}
 {-# language MultiParamTypeClasses #-}
 {-# language NamedFieldPuns #-}
 {-# language ScopedTypeVariables #-}
@@ -59,7 +58,7 @@ import Rel8.Kind.Algebra
   , KnownAlgebra, algebraSing
   )
 import qualified Rel8.Kind.Algebra as K
-import Rel8.Schema.Context.Nullify ( guardExpr, snullify )
+import Rel8.Schema.Context.Nullify ( sguard, snullify )
 import Rel8.Schema.HTable ( HTable )
 import Rel8.Schema.HTable.Identity ( HIdentity( HType ) )
 import qualified Rel8.Schema.Kind as K
@@ -349,7 +348,7 @@ ggaggregate gfromColumns gtoColumns agg es = case algebraSing @algebra of
       @(Eval (rep (Reify Aggregate)))
       (\(_ :: proxy x) -> toColumns . reify @_ @x Refl)
       (\tag' SSpec {nullity} (Reify (A (Aggregate a))) ->
-        Reify $ A $ Aggregate $ guardExpr (tag ==. litExpr tag') . snullify nullity <$> a)
+        Reify $ A $ Aggregate $ sguard (tag ==. litExpr tag') . snullify nullity <$> a)
       (HType (Reify (A (groupByExpr tag))))
     where
       f =

--- a/src/Rel8/Query/Either.hs
+++ b/src/Rel8/Query/Either.hs
@@ -10,6 +10,9 @@ where
 -- base
 import Prelude
 
+-- comonad
+import Control.Comonad ( extract )
+
 -- rel8
 import Rel8.Expr ( Expr )
 import Rel8.Expr.Eq ( (==.) )
@@ -27,14 +30,14 @@ import Rel8.Table.Maybe ( MaybeTable( MaybeTable ), isJustTable )
 keepLeftTable :: EitherTable Expr a b -> Query a
 keepLeftTable e@(EitherTable _ a _) = do
   where_ $ isLeftTable e
-  pure a
+  pure (extract a)
 
 
 -- | Filter 'EitherTable's, keeping only 'rightTable's.
 keepRightTable :: EitherTable Expr a b -> Query b
 keepRightTable e@(EitherTable _ _ b) = do
   where_ $ isRightTable e
-  pure b
+  pure (extract b)
 
 
 -- | @bitraverseEitherTable f g x@ will pass all @leftTable@s through @f@ and

--- a/src/Rel8/Schema/HTable/Nullify.hs
+++ b/src/Rel8/Schema/HTable/Nullify.hs
@@ -8,6 +8,7 @@
 {-# language LambdaCase #-}
 {-# language MultiParamTypeClasses #-}
 {-# language NamedFieldPuns #-}
+{-# language QuantifiedConstraints #-}
 {-# language RankNTypes #-}
 {-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
@@ -18,15 +19,24 @@
 module Rel8.Schema.HTable.Nullify
   ( HNullify( HNullify )
   , Nullify
-  , hnulls, hnullify, hunnullify
+  , hguard
+  , hnulls
+  , hnullify
+  , hunnullify
   )
 where
 
 -- base
+import GHC.Generics ( Generic )
 import Prelude hiding ( null )
 
 -- rel8
+import Rel8.FCF ( Eval, Exp )
 import Rel8.Schema.HTable ( HTable, hfield, htabulate, htabulateA, hspecs )
+import Rel8.Schema.HTable.MapTable
+  ( HMapTable, HMapTableField( HMapTableField )
+  , MapSpec, mapInfo
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
 import qualified Rel8.Schema.Null as Type ( Nullify )
@@ -34,16 +44,12 @@ import Rel8.Schema.Spec ( Spec( Spec ), SSpec(..) )
 
 -- semigroupoids
 import Data.Functor.Apply ( Apply )
-import Rel8.Schema.HTable.MapTable
-import Rel8.FCF
-import GHC.Generics (Generic)
 
 
 type HNullify :: K.HTable -> K.HTable
 newtype HNullify table context = HNullify (HMapTable Nullify table context)
   deriving stock Generic
   deriving anyclass HTable
-
 
 
 -- | Transform a 'Spec' by allowing it to be @null@.
@@ -61,7 +67,18 @@ instance MapSpec Nullify where
           Null    -> Null
           NotNull -> Null
       , ..
-      } 
+      }
+
+
+hguard :: HTable t
+  => (forall a. context ('Spec (Maybe a)) -> context ('Spec (Maybe a)))
+  -> HNullify t context -> HNullify t context
+hguard guarder (HNullify as) = HNullify $ htabulate $ \(HMapTableField field) ->
+  case hfield hspecs field of
+    SSpec {nullity} -> case hfield as (HMapTableField field) of
+      a -> case nullity of
+        Null -> guarder a
+        NotNull -> guarder a
 
 
 hnulls :: HTable t
@@ -69,8 +86,9 @@ hnulls :: HTable t
     => SSpec ('Spec a)
     -> context ('Spec (Type.Nullify a)))
   -> HNullify t context
-hnulls null = HNullify $ htabulate $ \(HMapTableField field) -> case hfield hspecs field of
-  spec@SSpec {} -> null spec
+hnulls null = HNullify $ htabulate $ \(HMapTableField field) ->
+  case hfield hspecs field of
+    spec@SSpec {} -> null spec
 {-# INLINABLE hnulls #-}
 
 

--- a/src/Rel8/Table/Nullify.hs
+++ b/src/Rel8/Table/Nullify.hs
@@ -1,0 +1,204 @@
+{-# language DataKinds #-}
+{-# language FlexibleInstances #-}
+{-# language LambdaCase #-}
+{-# language MultiParamTypeClasses #-}
+{-# language ScopedTypeVariables #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeApplications #-}
+{-# language TypeFamilies #-}
+{-# language UndecidableInstances #-}
+
+module Rel8.Table.Nullify
+  ( Nullify
+  , aggregateNullify
+  , guard
+  )
+where
+
+-- base
+import Control.Applicative ( liftA2 )
+import Control.Category ( id )
+import Data.Functor.Identity ( runIdentity )
+import Data.Kind ( Type )
+import Data.Type.Equality ( (:~:)( Refl ), apply )
+import Prelude hiding ( id )
+
+-- comonad
+import Control.Comonad ( Comonad, duplicate, extract, ComonadApply, (<@>) )
+
+-- rel8
+import Rel8.Aggregate ( Aggregate )
+import Rel8.Expr ( Expr )
+import Rel8.Kind.Context ( Reifiable, contextSing )
+import Rel8.Schema.Context ( Col )
+import Rel8.Schema.Context.Abstract ( Abstract, exclusivity, virtual )
+import Rel8.Schema.Context.Nullify
+  ( Nullifiability( NAggregate, NExpr )
+  , NonNullifiability( NNReify )
+  , Nullifiable, nullifiability
+  , nullifiableOrNot, absurd
+  , guarder
+  , nullifier
+  , unnullifier
+  )
+import Rel8.Schema.Dict ( Dict( Dict ) )
+import Rel8.Schema.HTable ( HTable )
+import Rel8.Schema.HTable.Nullify ( HNullify, hnullify, hunnullify, hguard )
+import qualified Rel8.Schema.Kind as K
+import Rel8.Schema.Reify ( hreify, hunreify )
+import Rel8.Schema.Spec ( Spec( Spec ) )
+import Rel8.Table
+  ( Table, Columns, Context, toColumns, fromColumns
+  , reify, unreify, coherence, congruence
+  )
+import Rel8.Table.Eq ( EqTable, eqTable )
+import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Recontextualize ( Recontextualize )
+
+-- semigroupoids
+import Data.Functor.Apply ( Apply, (<.>), liftF2 )
+import Data.Functor.Bind ( Bind, (>>-) )
+import Data.Functor.Extend ( Extend, duplicated )
+
+
+type Nullify :: K.Context -> Type -> Type
+data Nullify context a
+  = Table (Nullifiability context) a
+  | Fields (NonNullifiability context) (HNullify (Columns a) (Col (Context a)))
+
+
+instance Nullifiable context => Functor (Nullify context) where
+  fmap f = \case
+    Table nullifiable a -> Table nullifiable (f a)
+    Fields notNullifiable _ -> absurd nullifiability notNullifiable
+
+
+instance Nullifiable context => Foldable (Nullify context) where
+  foldMap f = \case
+    Table _ a -> f a
+    Fields notNullifiable _ -> absurd nullifiability notNullifiable
+
+
+instance Nullifiable context => Traversable (Nullify context) where
+  traverse f = \case
+    Table nullifiable a -> Table nullifiable <$> f a
+    Fields notNullifiable _ -> absurd nullifiability notNullifiable
+
+
+instance Nullifiable context => Apply (Nullify context) where
+  liftF2 f = \case
+    Table nullifiable a -> \case
+      Table _ b -> Table nullifiable (f a b)
+      Fields notNullifiable _ -> absurd nullifiable notNullifiable
+    Fields notNullifiable _ -> absurd nullifiability notNullifiable
+
+
+instance Nullifiable context => Applicative (Nullify context) where
+  pure = Table nullifiability
+  liftA2 = liftF2
+
+
+instance Nullifiable context => Bind (Nullify context) where
+  Table _ a >>- f = f a
+  Fields notNullifiable _ >>- _ = absurd nullifiability notNullifiable
+
+
+instance Nullifiable context => Monad (Nullify context) where
+  (>>=) = (>>-)
+
+
+instance Nullifiable context => Extend (Nullify context) where
+  duplicated = \case
+    Table nullifiable a -> Table nullifiable (Table nullifiable a)
+    Fields notNullifiable _ -> absurd nullifiability notNullifiable
+
+
+instance Nullifiable context => Comonad (Nullify context) where
+  extract = \case
+    Table _ a -> a
+    Fields notNullifiable _ -> absurd nullifiability notNullifiable
+  duplicate = duplicated
+
+
+instance Nullifiable context => ComonadApply (Nullify context) where
+  (<@>) = (<.>)
+
+
+instance
+  ( Table context a
+  , Reifiable context, Abstract context, context ~ context'
+  )
+  => Table context' (Nullify context a)
+ where
+  type Columns (Nullify context a) = HNullify (Columns a)
+  type Context (Nullify context a) = Context a
+
+  fromColumns = case nullifiableOrNot contextSing of
+    Left notNullifiable -> Fields notNullifiable
+    Right nullifiable ->
+      Table nullifiable .
+      fromColumns .
+      runIdentity .
+      hunnullify (\spec -> pure . unnullifier nullifiable spec)
+
+  toColumns = \case
+    Table nullifiable a -> hnullify (nullifier nullifiable) (toColumns a)
+    Fields _ a -> a
+
+  reify proof@Refl = \case
+    Table nullifiable a -> Table nullifiable (reify proof a)
+    Fields notNullifiable a -> case notNullifiable of
+      NNReify (_ :: NonNullifiability ctx) ->
+        case coherence @context @a proof abstract of
+          Refl -> case congruence @context @a proof abstract of
+            Refl -> Fields notNullifiable (hreify a)
+        where
+          abstract = exclusivity (virtual @ctx)
+
+  unreify proof@Refl = \case
+    Table nullifiable a -> Table nullifiable (unreify proof a)
+    Fields notNullifiable a -> case notNullifiable of
+      NNReify (_ :: NonNullifiability ctx) ->
+        case coherence @context @a proof abstract of
+          Refl -> case congruence @context @a proof abstract of
+            Refl -> Fields notNullifiable (hunreify a)
+        where
+          abstract = exclusivity (virtual @ctx)
+
+  coherence = coherence @context @a
+  congruence proof abstract = id `apply` congruence @context @a proof abstract
+
+
+instance
+  ( Recontextualize from to a b
+  , Reifiable from, Abstract from, from ~ from'
+  , Reifiable to, Abstract to, to ~ to'
+  )
+  => Recontextualize from' to' (Nullify from a) (Nullify to b)
+
+
+instance (EqTable a, context ~ Expr) => EqTable (Nullify context a) where
+  eqTable = hnullify (\_ Dict -> Dict) (eqTable @a)
+
+
+instance (OrdTable a, context ~ Expr) => OrdTable (Nullify context a) where
+  ordTable = hnullify (\_ Dict -> Dict) (ordTable @a)
+
+
+aggregateNullify :: ()
+  => (exprs -> aggregates)
+  -> Nullify Expr exprs
+  -> Nullify Aggregate aggregates
+aggregateNullify f = \case
+  Table _ a -> Table NAggregate (f a)
+  Fields notNullifiable _ -> absurd NExpr notNullifiable
+
+
+guard :: (Reifiable context, HTable t)
+  => Col context ('Spec tag)
+  -> (tag -> Bool)
+  -> (Expr tag -> Expr Bool)
+  -> HNullify t (Col context)
+  -> HNullify t (Col context)
+guard tag isNonNull isNonNullExpr =
+  hguard (guarder contextSing tag isNonNull isNonNullExpr)


### PR DESCRIPTION
This factors out some of the common code that was duplicated in Rel8.Table.Either, Rel8.Table.Maybe and Rel8.Table.These. But it's also more complex than this code was, because it provides for the possibility of a `MaybeTable` in a non-`Nullifiable` context which is a `Table`, but not a `Functor`. This is relevant for the `Projection` work.