### PR TITLE
Add `projection` smart constructor and `Field` context

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -121,6 +121,7 @@ library
     Rel8.Schema.Context.Nullify
     Rel8.Schema.Context.Virtual
     Rel8.Schema.Dict
+    Rel8.Schema.Field
     Rel8.Schema.HTable
     Rel8.Schema.HTable.Either
     Rel8.Schema.HTable.Identity

--- a/src/Rel8/Column.hs
+++ b/src/Rel8/Column.hs
@@ -16,6 +16,7 @@ import Prelude ()
 import Rel8.Aggregate ( Aggregate )
 import Rel8.Expr ( Expr )
 import Rel8.FCF ( Eval, Exp )
+import Rel8.Schema.Field ( Field )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name(..) )
 import Rel8.Schema.Result ( Result )
@@ -28,6 +29,7 @@ type Column :: K.Context -> Type -> Type
 type family Column context a where
   Column Aggregate       a = Aggregate a
   Column Expr            a = Expr a
+  Column (Field table)   a = Field table a
   Column Name            a = Name a
   Column Result          a = a
 

--- a/src/Rel8/Column/Either.hs
+++ b/src/Rel8/Column/Either.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.Either ( EitherTable )
 
@@ -25,7 +22,5 @@ import Rel8.Table.Either ( EitherTable )
 -- 'Result' context.
 type HEither :: K.Context -> Type -> Type -> Type
 type family HEither context = either | either -> context where
-  HEither Aggregate = EitherTable Aggregate
-  HEither Expr = EitherTable Expr
-  HEither Name = EitherTable Name
   HEither Result = Either
+  HEither context = EitherTable context

--- a/src/Rel8/Column/List.hs
+++ b/src/Rel8/Column/List.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude ()
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.List ( ListTable )
 
@@ -24,7 +21,5 @@ import Rel8.Table.List ( ListTable )
 -- @a@ in the 'Expr' context, and a @[a]@ in the 'Result' context.
 type HList :: K.Context -> Type -> Type
 type family HList context = list | list -> context where
-  HList Aggregate = ListTable Aggregate
-  HList Expr = ListTable Expr
-  HList Name = ListTable Name
   HList Result = []
+  HList context = ListTable context

--- a/src/Rel8/Column/Maybe.hs
+++ b/src/Rel8/Column/Maybe.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.Maybe ( MaybeTable )
 
@@ -25,7 +22,5 @@ import Rel8.Table.Maybe ( MaybeTable )
 -- context.
 type HMaybe :: K.Context -> Type -> Type
 type family HMaybe context = maybe | maybe -> context where
-  HMaybe Aggregate = MaybeTable Aggregate
-  HMaybe Expr = MaybeTable Expr
-  HMaybe Name = MaybeTable Name
   HMaybe Result = Maybe
+  HMaybe context = MaybeTable context

--- a/src/Rel8/Column/NonEmpty.hs
+++ b/src/Rel8/Column/NonEmpty.hs
@@ -13,10 +13,7 @@ import Data.List.NonEmpty ( NonEmpty )
 import Prelude ()
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.NonEmpty ( NonEmptyTable )
 
@@ -26,7 +23,5 @@ import Rel8.Table.NonEmpty ( NonEmptyTable )
 -- 'Result' context.
 type HNonEmpty :: K.Context -> Type -> Type
 type family HNonEmpty context = nonEmpty | nonEmpty -> context where
-  HNonEmpty Aggregate = NonEmptyTable Aggregate
-  HNonEmpty Expr = NonEmptyTable Expr
-  HNonEmpty Name = NonEmptyTable Name
   HNonEmpty Result = NonEmpty
+  HNonEmpty context = NonEmptyTable context

--- a/src/Rel8/Column/These.hs
+++ b/src/Rel8/Column/These.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude ()
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.These ( TheseTable )
 
@@ -28,7 +25,5 @@ import Data.These ( These )
 -- 'Result' context.
 type HThese :: K.Context -> Type -> Type -> Type
 type family HThese context = these | these -> context where
-  HThese Aggregate = TheseTable Aggregate
-  HThese Expr = TheseTable Expr
-  HThese Name = TheseTable Name
   HThese Result = These
+  HThese context = TheseTable context

--- a/src/Rel8/Kind/Context.hs
+++ b/src/Rel8/Kind/Context.hs
@@ -15,6 +15,7 @@ import Prelude ()
 -- rel8
 import Rel8.Aggregate ( Aggregate )
 import Rel8.Expr ( Expr )
+import Rel8.Schema.Field ( Field )
 import Rel8.Schema.Kind ( Context )
 import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
@@ -24,6 +25,7 @@ type SContext :: Context -> Type
 data SContext context where
   SAggregate :: SContext Aggregate
   SExpr :: SContext Expr
+  SField :: SContext (Field table)
   SName :: SContext Name
   SResult :: SContext Result
 
@@ -39,6 +41,10 @@ instance Reifiable Aggregate where
 
 instance Reifiable Expr where
   contextSing = SExpr
+
+
+instance Reifiable (Field table) where
+  contextSing = SField
 
 
 instance Reifiable Result where

--- a/src/Rel8/Schema/Context/Virtual.hs
+++ b/src/Rel8/Schema/Context/Virtual.hs
@@ -19,6 +19,7 @@ import Prelude
 import Rel8.Aggregate ( Aggregate )
 import Rel8.Expr ( Expr )
 import Rel8.Kind.Context ( SContext(..) )
+import Rel8.Schema.Field ( Field )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
@@ -37,6 +38,10 @@ instance Virtual Expr where
   virtual = VExpr
 
 
+instance Virtual (Field table) where
+  virtual = VField
+
+
 instance Virtual Name where
   virtual = VName
 
@@ -45,6 +50,7 @@ type Abstract :: K.Context -> Type
 data Abstract context where
   VAggregate :: Abstract Aggregate
   VExpr :: Abstract Expr
+  VField :: Abstract (Field table)
   VName :: Abstract Name
 
 
@@ -59,6 +65,7 @@ abstractOrConcrete :: ()
 abstractOrConcrete = \case
   SAggregate -> Right VAggregate
   SExpr -> Right VExpr
+  SField -> Right VField
   SName -> Right VName
   SResult -> Left VResult
 
@@ -67,4 +74,5 @@ absurd :: Abstract context -> Concrete context -> a
 absurd = \case
   VAggregate -> \case
   VExpr -> \case
+  VField -> \case
   VName -> \case

--- a/src/Rel8/Schema/Field.hs
+++ b/src/Rel8/Schema/Field.hs
@@ -1,0 +1,86 @@
+{-# language DataKinds #-}
+{-# language FlexibleContexts #-}
+{-# language GADTs #-}
+{-# language MultiParamTypeClasses #-}
+{-# language PolyKinds #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeFamilies #-}
+{-# language TypeOperators #-}
+
+module Rel8.Schema.Field
+  ( Field(..)
+  , fields
+  )
+where
+
+-- base
+import Data.Kind ( Type )
+import Data.Type.Equality ( type (~~) )
+import Prelude
+
+-- rel8
+import Rel8.Aggregate ( Aggregate )
+import Rel8.Expr ( Expr )
+import Rel8.Schema.HTable ( HField, htabulate, hfield, hspecs )
+import Rel8.Schema.Spec ( Spec( Spec ), SSpec( SSpec ) )
+import Rel8.Schema.HTable.Identity ( HIdentity( HType ), HType )
+import Rel8.Schema.Name ( Name )
+import Rel8.Schema.Null ( Sql )
+import Rel8.Schema.Result ( Result( R ) )
+import Rel8.Table
+  ( Table, Columns, Context, fromColumns, toColumns
+  , FromExprs, fromResult, toResult
+  )
+import Rel8.Table.Recontextualize ( Recontextualize )
+import Rel8.Type ( DBType )
+
+
+-- | A special context used in the construction of 'Rel8.Projection's.
+type Field :: Type -> k -> Type
+data Field table a where
+  Field :: a ~~ a' => HField (Columns table) ('Spec a') -> Field table a
+  F :: !(Field table a) -> Field table ('Spec a)
+
+
+instance Sql DBType a => Table (Field table) (Field table a) where
+  type Columns (Field table a) = HType a
+  type Context (Field table a) = Field table
+  type FromExprs (Field table a) = a
+
+  toColumns a = HType (F a)
+  fromColumns (HType (F a)) = a
+  toResult a = HType (R a)
+  fromResult (HType (R a)) = a
+
+
+instance Sql DBType a =>
+  Recontextualize Aggregate (Field t) (Aggregate a) (Field t a)
+
+
+instance Sql DBType a =>
+  Recontextualize Expr (Field t) (Expr a) (Field t a)
+
+
+instance Sql DBType a =>
+  Recontextualize (Field t) Aggregate (Field t a) (Aggregate a)
+
+
+instance Sql DBType a =>
+  Recontextualize (Field t) Expr (Field t a) (Expr a)
+
+
+instance Sql DBType a =>
+  Recontextualize (Field t) (Field t) (Field t a) (Field t a)
+
+
+instance Sql DBType a =>
+  Recontextualize (Field t) Name (Field t a) (Name a)
+
+
+instance Sql DBType a =>
+  Recontextualize Name (Field t) (Name a) (Field t a)
+
+
+fields :: Recontextualize context (Field table) table fields => fields
+fields = fromColumns $ htabulate $ \field -> case hfield hspecs field of
+  SSpec {} -> F $ Field field

--- a/src/Rel8/Table/ADT.hs
+++ b/src/Rel8/Table/ADT.hs
@@ -54,7 +54,6 @@ import Rel8.Generic.Rel8able
   )
 import qualified Rel8.Generic.Table.ADT as G
 import qualified Rel8.Kind.Algebra as K
-import Rel8.Schema.Context.Virtual
 import Rel8.Schema.HTable ( HTable )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name )
@@ -73,13 +72,8 @@ instance ADTable t => Rel8able (ADT t) where
   type GColumns (ADT t) = GColumnsADT t
   type GFromExprs (ADT t) = t Result
 
-  gfromColumns VAggregate = ADT
-  gfromColumns VExpr = ADT
-  gfromColumns VName = ADT
-
-  gtoColumns VAggregate (ADT a) = a
-  gtoColumns VExpr (ADT a) = a
-  gtoColumns VName (ADT a) = a
+  gfromColumns _ = ADT
+  gtoColumns _ (ADT a) = a
 
   gfromResult =
     unrecord .


### PR DESCRIPTION
`projection` gives a way more convenient way to construct `Projection`s using ordinary Haskell functions. This allows the use of pattern matching and record construction syntax. The `Field` context is an implementation detail of `projection`.