### PR TITLE
Add Projection and Field

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -116,6 +116,7 @@ library
 
     Rel8.Schema.Context.Nullify
     Rel8.Schema.Dict
+    Rel8.Schema.Field
     Rel8.Schema.HTable
     Rel8.Schema.HTable.Either
     Rel8.Schema.HTable.Identity
@@ -159,6 +160,7 @@ library
     Rel8.Table.Opaleye
     Rel8.Table.Ord
     Rel8.Table.Order
+    Rel8.Table.Projection
     Rel8.Table.Rel8able
     Rel8.Table.Serialize
     Rel8.Table.These

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -173,6 +173,13 @@ module Rel8
   , Query
   , showQuery
 
+    -- ** Projection
+  , Projection
+  , Projectable( project )
+  , Biprojectable( biproject )
+  , Projecting
+  , Field
+
     -- ** Selecting rows
   , Selects
   , each
@@ -317,6 +324,7 @@ import Rel8.Query.SQL (showQuery)
 import Rel8.Query.Set
 import Rel8.Query.These
 import Rel8.Query.Values
+import Rel8.Schema.Field
 import Rel8.Schema.HTable
 import Rel8.Schema.Name
 import Rel8.Schema.Null hiding ( nullable )
@@ -342,6 +350,7 @@ import Rel8.Table.Name
 import Rel8.Table.NonEmpty
 import Rel8.Table.Ord
 import Rel8.Table.Order
+import Rel8.Table.Projection
 import Rel8.Table.Rel8able ()
 import Rel8.Table.Serialize
 import Rel8.Table.These

--- a/src/Rel8/Column/Either.hs
+++ b/src/Rel8/Column/Either.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.Either ( EitherTable )
 
@@ -25,7 +22,5 @@ import Rel8.Table.Either ( EitherTable )
 -- 'Result' context.
 type HEither :: K.Context -> Type -> Type -> Type
 type family HEither context = either | either -> context where
-  HEither Aggregate = EitherTable Aggregate
-  HEither Expr = EitherTable Expr
-  HEither Name = EitherTable Name
   HEither Result = Either
+  HEither context = EitherTable context

--- a/src/Rel8/Column/List.hs
+++ b/src/Rel8/Column/List.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude ()
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.List ( ListTable )
 
@@ -24,7 +21,5 @@ import Rel8.Table.List ( ListTable )
 -- @a@ in the 'Expr' context, and a @[a]@ in the 'Result' context.
 type HList :: K.Context -> Type -> Type
 type family HList context = list | list -> context where
-  HList Aggregate = ListTable Aggregate
-  HList Expr = ListTable Expr
-  HList Name = ListTable Name
   HList Result = []
+  HList context = ListTable context

--- a/src/Rel8/Column/Maybe.hs
+++ b/src/Rel8/Column/Maybe.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.Maybe ( MaybeTable )
 
@@ -25,7 +22,5 @@ import Rel8.Table.Maybe ( MaybeTable )
 -- context.
 type HMaybe :: K.Context -> Type -> Type
 type family HMaybe context = maybe | maybe -> context where
-  HMaybe Aggregate = MaybeTable Aggregate
-  HMaybe Expr = MaybeTable Expr
-  HMaybe Name = MaybeTable Name
   HMaybe Result = Maybe
+  HMaybe context = MaybeTable context

--- a/src/Rel8/Column/NonEmpty.hs
+++ b/src/Rel8/Column/NonEmpty.hs
@@ -13,10 +13,7 @@ import Data.List.NonEmpty ( NonEmpty )
 import Prelude ()
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.NonEmpty ( NonEmptyTable )
 
@@ -26,7 +23,5 @@ import Rel8.Table.NonEmpty ( NonEmptyTable )
 -- 'Result' context.
 type HNonEmpty :: K.Context -> Type -> Type
 type family HNonEmpty context = nonEmpty | nonEmpty -> context where
-  HNonEmpty Aggregate = NonEmptyTable Aggregate
-  HNonEmpty Expr = NonEmptyTable Expr
-  HNonEmpty Name = NonEmptyTable Name
   HNonEmpty Result = NonEmpty
+  HNonEmpty context = NonEmptyTable context

--- a/src/Rel8/Column/These.hs
+++ b/src/Rel8/Column/These.hs
@@ -12,10 +12,7 @@ import Data.Kind ( Type )
 import Prelude ()
 
 -- rel8
-import Rel8.Aggregate ( Aggregate )
-import Rel8.Expr ( Expr )
 import qualified Rel8.Schema.Kind as K
-import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
 import Rel8.Table.These ( TheseTable )
 
@@ -28,7 +25,5 @@ import Data.These ( These )
 -- 'Result' context.
 type HThese :: K.Context -> Type -> Type -> Type
 type family HThese context = these | these -> context where
-  HThese Aggregate = TheseTable Aggregate
-  HThese Expr = TheseTable Expr
-  HThese Name = TheseTable Name
   HThese Result = These
+  HThese context = TheseTable context

--- a/src/Rel8/Kind/Context.hs
+++ b/src/Rel8/Kind/Context.hs
@@ -16,6 +16,7 @@ import Prelude ()
 -- rel8
 import Rel8.Aggregate ( Aggregate )
 import Rel8.Expr ( Expr )
+import Rel8.Schema.Field ( Field )
 import Rel8.Schema.Kind ( Context )
 import Rel8.Schema.Name ( Name )
 import Rel8.Schema.Result ( Result )
@@ -25,6 +26,7 @@ type SContext :: Context -> Type
 data SContext context where
   SAggregate :: SContext Aggregate
   SExpr :: SContext Expr
+  SField :: SContext (Field table)
   SName :: SContext Name
   SResult :: SContext Result
 
@@ -40,6 +42,10 @@ instance Reifiable Aggregate where
 
 instance Reifiable Expr where
   contextSing = SExpr
+
+
+instance Reifiable (Field table) where
+  contextSing = SField
 
 
 instance Reifiable Result where

--- a/src/Rel8/Schema/Field.hs
+++ b/src/Rel8/Schema/Field.hs
@@ -1,0 +1,50 @@
+{-# language DataKinds #-}
+{-# language FlexibleContexts #-}
+{-# language MultiParamTypeClasses #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeFamilies #-}
+
+module Rel8.Schema.Field
+  ( Field(..)
+  , fields
+  )
+where
+
+-- base
+import Data.Functor.Identity ( Identity( Identity ) )
+import Data.Kind ( Type )
+import Prelude
+
+-- rel8
+import Rel8.Schema.HTable ( HField, htabulate )
+import Rel8.Schema.HTable.Identity ( HIdentity( HIdentity ) )
+import Rel8.Schema.Kind as K
+import Rel8.Schema.Null ( Sql )
+import Rel8.Table
+  ( Table, Columns, Context, fromColumns, toColumns
+  , FromExprs, fromResult, toResult
+  , Transpose
+  )
+import Rel8.Table.Transpose ( Transposes )
+import Rel8.Type ( DBType )
+
+
+-- | A special context used in the construction of 'Rel8.Projection's.
+type Field :: Type -> K.Context
+newtype Field table a = Field (HField (Columns table) a)
+
+
+instance Sql DBType a => Table (Field table) (Field table a) where
+  type Columns (Field table a) = HIdentity a
+  type Context (Field table a) = Field table
+  type FromExprs (Field table a) = a
+  type Transpose to (Field table a) = to a
+
+  toColumns = HIdentity
+  fromColumns (HIdentity a) = a
+  toResult a = HIdentity (Identity a)
+  fromResult (HIdentity (Identity a)) = a
+
+
+fields :: Transposes context (Field table) table fields => fields
+fields = fromColumns $ htabulate Field

--- a/src/Rel8/Schema/HTable/Label.hs
+++ b/src/Rel8/Schema/HTable/Label.hs
@@ -1,4 +1,5 @@
 {-# language DataKinds #-}
+{-# language RankNTypes #-}
 {-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
@@ -7,6 +8,7 @@
 
 module Rel8.Schema.HTable.Label
   ( HLabel, hlabel, hrelabel, hunlabel
+  , hproject
   )
 where
 
@@ -18,6 +20,9 @@ import Prelude
 
 -- rel8
 import Rel8.Schema.HTable
+  ( HTable, HConstrainTable, HField
+  , htabulate, hfield, htraverse, hdicts, hspecs
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Spec ( Spec(..) )
 
@@ -57,3 +62,9 @@ hrelabel = hlabel . hunlabel
 hunlabel :: forall label t context. HLabel label t context -> t context
 hunlabel (HLabel a) = a
 {-# INLINABLE hunlabel #-}
+
+
+hproject :: ()
+  => (forall ctx. t ctx -> t' ctx)
+  -> HLabel label t context -> HLabel label t' context
+hproject f (HLabel a) = HLabel (f a)

--- a/src/Rel8/Schema/HTable/MapTable.hs
+++ b/src/Rel8/Schema/HTable/MapTable.hs
@@ -6,6 +6,7 @@
 {-# language GADTs #-}
 {-# language InstanceSigs #-}
 {-# language MultiParamTypeClasses #-}
+{-# language RankNTypes #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
@@ -18,6 +19,7 @@ module Rel8.Schema.HTable.MapTable
   , MapSpec(..)
   , Precompose(..)
   , HMapTableField(..)
+  , hproject
   )
 where
 
@@ -89,3 +91,9 @@ class MapSpec f where
 type ComposeConstraint :: (Type -> Exp Type) -> (Type -> Constraint) -> Type -> Constraint
 class c (Eval (f a)) => ComposeConstraint f c a
 instance c (Eval (f a)) => ComposeConstraint f c a
+
+
+hproject :: ()
+  => (forall ctx. t ctx -> t' ctx)
+  -> HMapTable f t context -> HMapTable f t' context
+hproject f (HMapTable a) = HMapTable (f a)

--- a/src/Rel8/Schema/HTable/Nullify.hs
+++ b/src/Rel8/Schema/HTable/Nullify.hs
@@ -23,6 +23,7 @@ module Rel8.Schema.HTable.Nullify
   , hnulls
   , hnullify
   , hunnullify
+  , hproject
   )
 where
 
@@ -38,6 +39,7 @@ import Rel8.Schema.HTable.MapTable
   ( HMapTable, HMapTableField( HMapTableField )
   , MapSpec, mapInfo
   )
+import qualified Rel8.Schema.HTable.MapTable as HMapTable ( hproject )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
 import qualified Rel8.Schema.Null as Type ( Nullify )
@@ -107,3 +109,9 @@ hunnullify unnullifier (HNullify as) =
     spec@Spec {} -> case hfield as (HMapTableField field) of
       a -> unnullifier spec a
 {-# INLINABLE hunnullify #-}
+
+
+hproject :: ()
+  => (forall ctx. t ctx -> t' ctx)
+  -> HNullify t context -> HNullify t' context
+hproject f (HNullify a) = HNullify (HMapTable.hproject f a)

--- a/src/Rel8/Schema/HTable/Vectorize.hs
+++ b/src/Rel8/Schema/HTable/Vectorize.hs
@@ -21,18 +21,26 @@ module Rel8.Schema.HTable.Vectorize
   ( HVectorize
   , hvectorize, hunvectorize
   , happend, hempty
+  , hproject
   )
 where
 
 -- base
 import Data.Kind ( Type )
 import Data.List.NonEmpty ( NonEmpty )
+import GHC.Generics (Generic)
 import Prelude
 
 -- rel8
+import Rel8.FCF ( Eval, Exp )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.HTable ( HTable, hfield, htabulate, htabulateA, hspecs )
+import Rel8.Schema.HTable.MapTable
+  ( HMapTable, HMapTableField( HMapTableField )
+  , MapSpec, mapInfo
+  )
+import qualified Rel8.Schema.HTable.MapTable as HMapTable ( hproject )
 import Rel8.Schema.Null ( Unnullify, NotNull, Nullity( NotNull ) )
 import Rel8.Schema.Spec ( Spec(..) )
 import Rel8.Type.Array ( listTypeInformation, nonEmptyTypeInformation )
@@ -40,9 +48,6 @@ import Rel8.Type.Information ( TypeInformation )
 
 -- semialign
 import Data.Zip ( Unzip, Zip, Zippy(..) )
-import Rel8.FCF
-import Rel8.Schema.HTable.MapTable
-import GHC.Generics (Generic)
 
 
 class Vector list where
@@ -122,3 +127,9 @@ hempty :: HTable t
   -> HVectorize [] t context
 hempty empty = HVectorize $ htabulate $ \(HMapTableField field) ->
   empty (hfield hspecs field)
+
+
+hproject :: ()
+  => (forall ctx. t ctx -> t' ctx)
+  -> HVectorize list t context -> HVectorize list t' context
+hproject f (HVectorize a) = HVectorize (HMapTable.hproject f a)

--- a/src/Rel8/Table/Either.hs
+++ b/src/Rel8/Table/Either.hs
@@ -54,6 +54,7 @@ import Rel8.Table.Bool ( bool )
 import Rel8.Table.Eq ( EqTable, eqTable )
 import Rel8.Table.Nullify ( Nullify, aggregateNullify, guard )
 import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Biprojectable, Projectable, biproject, project )
 import Rel8.Table.Serialize ( ToExprs )
 import Rel8.Table.Undefined ( undefined )
 import Rel8.Type.Tag ( EitherTag( IsLeft, IsRight ), isLeft, isRight )
@@ -78,8 +79,17 @@ data EitherTable context a b = EitherTable
   deriving stock Functor
 
 
+instance Biprojectable (EitherTable context) where
+  biproject f g (EitherTable tag a b) =
+    EitherTable tag (project f a) (project g b)
+
+
 instance Nullifiable context => Bifunctor (EitherTable context) where
   bimap f g (EitherTable tag a b) = EitherTable tag (fmap f a) (fmap g b)
+
+
+instance Projectable (EitherTable context a) where
+  project f (EitherTable tag a b) = EitherTable tag a (project f b)
 
 
 instance (context ~ Expr, Table Expr a) => Apply (EitherTable context a) where

--- a/src/Rel8/Table/List.hs
+++ b/src/Rel8/Table/List.hs
@@ -25,7 +25,11 @@ import Rel8.Expr ( Expr )
 import Rel8.Expr.Array ( sappend, sempty, slistOf )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.HTable.List ( HListTable )
-import Rel8.Schema.HTable.Vectorize ( happend, hempty, hvectorize, hunvectorize )
+import Rel8.Schema.HTable.Vectorize
+  ( hvectorize, hunvectorize
+  , happend, hempty
+  , hproject
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name( Name ) )
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
@@ -42,6 +46,7 @@ import Rel8.Table.Alternative
   )
 import Rel8.Table.Eq ( EqTable, eqTable )
 import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Projectable, project, apply )
 import Rel8.Table.Serialize ( ToExprs )
 
 
@@ -50,6 +55,10 @@ import Rel8.Table.Serialize ( ToExprs )
 type ListTable :: K.Context -> Type -> Type
 newtype ListTable context a =
   ListTable (HListTable (Columns a) (Context a))
+
+
+instance Projectable (ListTable context) where
+  project f (ListTable a) = ListTable (hproject (apply f) a)
 
 
 instance (Table context a, context ~ context') =>

--- a/src/Rel8/Table/Maybe.hs
+++ b/src/Rel8/Table/Maybe.hs
@@ -58,6 +58,7 @@ import Rel8.Table.Alternative
 import Rel8.Table.Bool ( bool )
 import Rel8.Table.Eq ( EqTable, eqTable )
 import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Projectable, project )
 import Rel8.Table.Nullify ( Nullify, aggregateNullify, guard )
 import Rel8.Table.Serialize ( ToExprs )
 import Rel8.Table.Undefined ( undefined )
@@ -83,6 +84,10 @@ data MaybeTable context a = MaybeTable
   , just :: Nullify context a
   }
   deriving stock Functor
+
+
+instance Projectable (MaybeTable context) where
+  project f (MaybeTable tag a) = MaybeTable tag (project f a)
 
 
 instance context ~ Expr => Apply (MaybeTable context) where

--- a/src/Rel8/Table/NonEmpty.hs
+++ b/src/Rel8/Table/NonEmpty.hs
@@ -26,7 +26,11 @@ import Rel8.Expr ( Expr )
 import Rel8.Expr.Array ( sappend1, snonEmptyOf )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.HTable.NonEmpty ( HNonEmptyTable )
-import Rel8.Schema.HTable.Vectorize ( happend, hvectorize, hunvectorize )
+import Rel8.Schema.HTable.Vectorize
+  ( hvectorize, hunvectorize
+  , happend
+  , hproject
+  )
 import qualified Rel8.Schema.Kind as K
 import Rel8.Schema.Name ( Name( Name ) )
 import Rel8.Schema.Null ( Nullity( Null, NotNull ) )
@@ -40,6 +44,7 @@ import Rel8.Table
 import Rel8.Table.Alternative ( AltTable, (<|>:) )
 import Rel8.Table.Eq ( EqTable, eqTable )
 import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Projectable, project, apply )
 import Rel8.Table.Serialize ( ToExprs )
 
 
@@ -48,6 +53,10 @@ import Rel8.Table.Serialize ( ToExprs )
 type NonEmptyTable :: K.Context -> Type -> Type
 newtype NonEmptyTable context a =
   NonEmptyTable (HNonEmptyTable (Columns a) (Context a))
+
+
+instance Projectable (NonEmptyTable context) where
+  project f (NonEmptyTable a) = NonEmptyTable (hproject (apply f) a)
 
 
 instance (Table context a, context ~ context') =>

--- a/src/Rel8/Table/Nullify.hs
+++ b/src/Rel8/Table/Nullify.hs
@@ -39,7 +39,11 @@ import Rel8.Schema.Context.Nullify
   )
 import Rel8.Schema.Dict ( Dict( Dict ) )
 import Rel8.Schema.HTable ( HTable )
-import Rel8.Schema.HTable.Nullify ( HNullify, hnulls, hnullify, hunnullify, hguard )
+import Rel8.Schema.HTable.Nullify
+  ( HNullify, hnulls, hnullify, hunnullify
+  , hguard
+  , hproject
+  )
 import qualified Rel8.Schema.Kind as K
 import qualified Rel8.Schema.Result as R
 import Rel8.Table
@@ -49,6 +53,7 @@ import Rel8.Table
   )
 import Rel8.Table.Eq ( EqTable, eqTable )
 import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Projectable, apply, project )
 
 -- semigroupoids
 import Data.Functor.Apply ( Apply, (<.>), liftF2 )
@@ -60,6 +65,12 @@ type Nullify :: K.Context -> Type -> Type
 data Nullify context a
   = Table (Nullifiability context) a
   | Fields (NonNullifiability context) (HNullify (Columns a) (Context a))
+
+
+instance Projectable (Nullify context) where
+  project f = \case
+    Table nullifiable a -> Table nullifiable (fromColumns (apply f (toColumns a)))
+    Fields nonNullifiable a -> Fields nonNullifiable (hproject (apply f) a)
 
 
 instance Nullifiable context => Functor (Nullify context) where

--- a/src/Rel8/Table/Projection.hs
+++ b/src/Rel8/Table/Projection.hs
@@ -1,0 +1,73 @@
+{-# language FlexibleContexts #-}
+{-# language FlexibleInstances #-}
+{-# language MonoLocalBinds #-}
+{-# language MultiParamTypeClasses #-}
+{-# language StandaloneKindSignatures #-}
+{-# language UndecidableInstances #-}
+
+module Rel8.Table.Projection
+  ( Projection
+  , Projectable( project )
+  , Biprojectable( biproject )
+  , Projecting
+  , apply
+  )
+where
+
+-- base
+import Data.Kind ( Constraint, Type )
+import Prelude
+
+-- rel8
+import Rel8.Schema.Field ( Field( Field ), fields )
+import Rel8.Schema.HTable ( hfield, htabulate )
+import Rel8.Table ( Columns, Context, Transpose, toColumns )
+import Rel8.Table.Transpose ( Transposes )
+
+
+-- | The constraint @'Projecting' a b@ ensures that @'Projection' a b@ is a
+-- usable 'Projection'.
+type Projecting :: Type -> Type -> Constraint
+class
+  ( Transposes (Field a) (Context a) a (Transpose (Field a) a)
+  , Transposes (Field a) (Context a) b (Transpose (Field a) b)
+  )
+  => Projecting a b
+instance
+  ( Transposes (Field a) (Context a) a (Transpose (Field a) a)
+  , Transposes (Field a) (Context a) b (Transpose (Field b) b)
+  )
+  => Projecting a b
+
+
+-- | A @'Projection' a b@s is a special type of function @a -> b@ whereby the
+-- resulting @b@ is guaranteed to be composed only from columns contained in
+-- @a@.
+type Projection :: Type -> Type -> Type
+type Projection a b = Transpose (Field a) a -> Transpose (Field a) b
+
+
+-- | @'Projectable' f@ means that @f@ is a kind of functor on 'Rel8.Table's
+-- that allows the mapping of a 'Projection' over its underlying columns.
+type Projectable :: (Type -> Type) -> Constraint
+class Projectable f where
+  -- | Map a 'Projection' over @f@.
+  project :: Projecting a b
+    => Projection a b -> f a -> f b
+
+
+-- | @'Biprojectable' p@ means that @p@ is a kind of bifunctor on
+-- 'Rel8.Table's that allows the mapping of a pair of 'Projection's  over its
+-- underlying columns.
+type Biprojectable :: (Type -> Type -> Type) -> Constraint
+class Biprojectable p where
+  -- | Map a pair of 'Projection's over @p@.
+  biproject :: (Projecting a b, Projecting c d)
+    => Projection a b -> Projection c d -> p a c -> p b d
+
+
+apply :: Projecting a b
+  => Projection a b -> Columns a context -> Columns b context
+apply f a = case toColumns (f fields) of
+  bs -> htabulate $ \field -> case hfield bs field of
+    Field field' -> hfield a field'

--- a/src/Rel8/Table/These.hs
+++ b/src/Rel8/Table/These.hs
@@ -60,6 +60,7 @@ import Rel8.Table.Maybe
   )
 import Rel8.Table.Nullify ( Nullify, guard )
 import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Biprojectable, Projectable, biproject, project )
 import Rel8.Table.Serialize ( ToExprs )
 import Rel8.Table.Undefined ( undefined )
 import Rel8.Type.Tag ( MaybeTag )
@@ -88,8 +89,16 @@ data TheseTable context a b = TheseTable
   deriving stock Functor
 
 
+instance Biprojectable (TheseTable context) where
+  biproject f g (TheseTable a b) = TheseTable (project f a) (project g b)
+
+
 instance Nullifiable context => Bifunctor (TheseTable context) where
   bimap f g (TheseTable a b) = TheseTable (fmap f a) (fmap g b)
+
+
+instance Projectable (TheseTable context a) where
+  project f (TheseTable a b) = TheseTable a (project f b)
 
 
 instance (context ~ Expr, Table Expr a, Semigroup a) =>


### PR DESCRIPTION
A `Projection a b` is a special type of function `a -> b` whereby the resulting `b` is guaranteed to be composed only from columns contained in `a`.

We can use this fact to give `ListTable` and `NonEmptyTable` a limited kind of functor. We call this functor `Projectable`, and its `fmap` is called `project`. There's also `Biprojectable` and `biproject` for `EitherTable` and `TheseTable`.