### PR TITLE
Fix Rel8able to work with polymorphic types

### DIFF
--- a/src/Rel8/Generic/Rel8able.hs
+++ b/src/Rel8/Generic/Rel8able.hs
@@ -60,9 +60,15 @@ type KRel8able :: Type
 type KRel8able = K.Rel8able
 
 
+-- This is almost 'Data.Type.Equality.==', but we add an extra case.
 type (==) :: k -> k -> Bool
 type family a == b where
+  -- This extra case is needed to solve the equation "a == Identity a", 
+  -- which occurs when we have polymorphic Rel8ables 
+  -- (e.g., newtype T a f = T { x :: Column f a })
   a == Identity a = 'False
+  
+  -- These cases are exactly the same as those in 'Data.Type.Equality.==.
   f a == g b = f == g && a == b
   a == a = 'True
   _ == _ = 'False

--- a/src/Rel8/Generic/Rel8able.hs
+++ b/src/Rel8/Generic/Rel8able.hs
@@ -26,9 +26,9 @@ module Rel8.Generic.Rel8able
 where
 
 -- base
-import Data.Type.Bool ( type (&&) )
 import Data.Functor.Identity ( Identity )
 import Data.Kind ( Constraint, Type )
+import Data.Type.Bool ( type (&&) )
 import GHC.Generics ( Generic, Rep, from, to )
 import Prelude
 

--- a/src/Rel8/Generic/Rel8able.hs
+++ b/src/Rel8/Generic/Rel8able.hs
@@ -6,6 +6,7 @@
 {-# language FlexibleInstances #-}
 {-# language LambdaCase #-}
 {-# language MultiParamTypeClasses #-}
+{-# language PolyKinds #-}
 {-# language QuantifiedConstraints #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
@@ -25,8 +26,9 @@ module Rel8.Generic.Rel8able
 where
 
 -- base
+import Data.Type.Bool ( type (&&) )
+import Data.Functor.Identity ( Identity )
 import Data.Kind ( Constraint, Type )
-import Data.Type.Equality ( type (==) )
 import GHC.Generics ( Generic, Rep, from, to )
 import Prelude
 
@@ -56,6 +58,14 @@ import Rel8.Table.Transpose ( Transposes )
 -- | The kind of 'Rel8able' types
 type KRel8able :: Type
 type KRel8able = K.Rel8able
+
+
+type (==) :: k -> k -> Bool
+type family a == b where
+  a == Identity a = 'False
+  f a == g b = f == g && a == b
+  a == a = 'True
+  _ == _ = 'False
 
 
 type Serialize :: Bool -> Type -> Type -> Constraint

--- a/tests/Rel8/Generic/Rel8able/Test.hs
+++ b/tests/Rel8/Generic/Rel8able/Test.hs
@@ -169,3 +169,10 @@ data NestedTableTestB f = NestedTableTestB
   }
   deriving stock Generic
   deriving anyclass Rel8able
+
+
+
+newtype IdRecord a f = IdRecord { recordId :: Column f a } deriving Generic
+
+
+instance DBType a => Rel8able (IdRecord a)

--- a/tests/Rel8/Generic/Rel8able/Test.hs
+++ b/tests/Rel8/Generic/Rel8able/Test.hs
@@ -172,7 +172,8 @@ data NestedTableTestB f = NestedTableTestB
 
 
 
-newtype IdRecord a f = IdRecord { recordId :: Column f a } deriving Generic
+newtype IdRecord a f = IdRecord { recordId :: Column f a }
+  deriving stock Generic
 
 
 instance DBType a => Rel8able (IdRecord a)


### PR DESCRIPTION
Currently, a declaration such as:

```haskell
newtype IdRecord a f = IdRecord { recordId :: Column f a } deriving Generic
instance DBType a => Rel8able (IdRecord a)
```

Will fail, producing the error:

```
    • Could not deduce (rel8-1.0.0.1:Rel8.Generic.Rel8able.Serialize
                          (a Data.Type.Equality.== Identity a) (Expr a) a)
        arising from a use of ‘rel8-1.0.0.1:Rel8.Generic.Rel8able.$dmgfromColumns’
      from the context: DBType a
        bound by the instance declaration
        at lib/CircuitHub/Model/Types.hs:231:10-42
```

The stuck `==` type family gets in the way, even though we can clearly see that this is `False`. This commit fixes this error by introducing a variation of `==` that anticipates this case, adding an explicit pattern. With this new definition of `==`, things work as expected.