### PR TITLE
Remove DBax and DBMin instances for Bool

### DIFF
--- a/src/Rel8/Type/Ord.hs
+++ b/src/Rel8/Type/Ord.hs
@@ -75,7 +75,6 @@ instance Sql DBOrd a => DBOrd (NonEmpty a)
 -- | The class of database types that support the @max@ aggregation function.
 type DBMax :: Type -> Constraint
 class DBOrd a => DBMax a
-instance DBMax Bool
 instance DBMax Char
 instance DBMax Int16
 instance DBMax Int32
@@ -101,7 +100,6 @@ instance Sql DBMax a => DBMax (NonEmpty a)
 -- | The class of database types that support the @min@ aggregation function.
 type DBMin :: Type -> Constraint
 class DBOrd a => DBMin a
-instance DBMin Bool
 instance DBMin Char
 instance DBMin Int16
 instance DBMin Int32


### PR DESCRIPTION
TIL that these don't work. I guess bool_and and bool_or are equivalent and more explicit.