### PR TITLE
Fix Projections (needed for UPSERT support)

### DIFF
--- a/src/Rel8/Table/Projection.hs
+++ b/src/Rel8/Table/Projection.hs
@@ -35,7 +35,7 @@ class
   => Projecting a b
 instance
   ( Transposes (Context a) (Field a) a (Transpose (Field a) a)
-  , Transposes (Context a) (Field a) b (Transpose (Field b) b)
+  , Transposes (Context a) (Field a) b (Transpose (Field a) b)
   )
   => Projecting a b
 


### PR DESCRIPTION
The definition of `Projecting` had a small typo in it which made it impossible to construct `Projection`s in the way described in the documentation.

This partially fixes is #131 (but not completely because we could still do with better documentation in general around this).