### PR TITLE
Export OrdTable operations

### DIFF
--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -47,7 +47,7 @@ module Rel8
   , AltTable((<|>:))
   , AlternativeTable( emptyTable )
   , EqTable, (==:), (/=:)
-  , OrdTable, ascTable, descTable
+  , OrdTable, (<:), (<=:), (>:), (>=:), ascTable, descTable, greatest, least
   , lit
   , bool
   , case_


### PR DESCRIPTION
`<:`, `<=:`, `>:`, `>=:`, `greatest` and `least`