### PR TITLE
Doc fix for except

### DIFF
--- a/src/Rel8/Query/Set.hs
+++ b/src/Rel8/Query/Set.hs
@@ -47,7 +47,7 @@ intersectAll = zipOpaleyeWith (Opaleye.intersectAllExplicit binaryspec)
 
 
 -- | Find the difference of two queries, collapsing duplicates @except a b@ is
--- the same as the SQL statement @x INTERSECT b@.
+-- the same as the SQL statement @x EXCEPT b@.
 except :: EqTable a => Query a -> Query a -> Query a
 except = zipOpaleyeWith (Opaleye.exceptExplicit binaryspec)
 


### PR DESCRIPTION
One question I have is that all the examples in this module are of the form

```
@foo a b@ is the same as the SQL statement @x FOO b@.
```

Should these say `... @a FOO b@` instead?