### PR TITLE
Rename div and mod to quot and rem and introduce proper div and mod

### DIFF
--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -139,6 +139,7 @@ module Rel8
     -- ** @null@
   , NotNull
   , Nullable
+  , Homonullable
   , null
   , nullify
   , nullable

--- a/src/Rel8/Expr/Num.hs
+++ b/src/Rel8/Expr/Num.hs
@@ -4,18 +4,24 @@
 {-# options_ghc -fno-warn-redundant-constraints #-}
 
 module Rel8.Expr.Num
-  ( fromIntegral, realToFrac, div, mod, ceiling, floor, round, truncate
+  ( fromIntegral
+  , realToFrac
+  , div, mod, divMod
+  , quot, rem, quotRem
+  , ceiling, floor, round, truncate
   )
 where
 
 -- base
-import Prelude ()
+import Prelude ( (+), (-), fst, negate, signum, snd )
 
 -- rel
 import Rel8.Expr ( Expr( Expr ) )
+import Rel8.Expr.Eq ( (==.) )
 import Rel8.Expr.Function ( function )
 import Rel8.Expr.Opaleye ( castExpr )
 import Rel8.Schema.Null ( Homonullable, Sql )
+import Rel8.Table.Bool ( bool )
 import Rel8.Type.Num ( DBFractional, DBIntegral, DBNum )
 
 
@@ -42,14 +48,41 @@ ceiling :: (Sql DBFractional a, Sql DBIntegral b, Homonullable a b)
 ceiling = function "ceiling"
 
 
--- | Perform integral division. Corresponds to the @div()@ function.
+-- | Emulates the behaviour of the Haskell function 'Prelude.div' in
+-- PostgreSQL.
 div :: Sql DBIntegral a => Expr a -> Expr a -> Expr a
-div = function "div"
+div n d = fst (divMod n d)
 
 
--- | Corresponds to the @mod()@ function.
+-- | Emulates the behaviour of the Haskell function 'Prelude.mod' in
+-- PostgreSQL.
 mod :: Sql DBIntegral a => Expr a -> Expr a -> Expr a
-mod = function "mod"
+mod n d = snd (divMod n d)
+
+
+-- | Simultaneous 'div' and 'mod'.
+divMod :: Sql DBIntegral a => Expr a -> Expr a -> (Expr a, Expr a)
+divMod n d = bool qr (q - 1, r + d) (signum r ==. negate (signum d))
+  where
+    qr@(q, r) = quotRem n d
+
+
+-- | Perform integral division. Corresponds to the @div()@ function in
+-- PostgreSQL, which behaves like Haskell's 'Prelude.quot' rather than
+-- 'Prelude.div'.
+quot :: Sql DBIntegral a => Expr a -> Expr a -> Expr a
+quot = function "div"
+
+
+-- | Corresponds to the @mod()@ function in PostgreSQL, which behaves like
+-- Haskell's 'Prelude.rem' rather than 'Prelude.mod'.
+rem :: Sql DBIntegral a => Expr a -> Expr a -> Expr a
+rem = function "mod"
+
+
+-- | Simultaneous 'quot' and 'rem'.
+quotRem :: Sql DBIntegral a => Expr a -> Expr a -> (Expr a, Expr a)
+quotRem n d = (quot n d, rem n d)
 
 
 -- | Round a 'DFractional' to a 'DBIntegral' by rounding to the nearest smaller

--- a/src/Rel8/Type/Num.hs
+++ b/src/Rel8/Type/Num.hs
@@ -18,6 +18,7 @@ import Prelude
 
 -- rel8
 import Rel8.Type ( DBType )
+import Rel8.Type.Ord ( DBOrd )
 
 -- scientific
 import Data.Scientific ( Scientific )
@@ -39,7 +40,7 @@ instance DBNum Scientific
 -- expressions. This is a Rel8 concept, and allows us to provide
 -- 'fromIntegral'.
 type DBIntegral :: Type -> Constraint
-class DBNum a => DBIntegral a
+class (DBNum a, DBOrd a) => DBIntegral a
 instance DBIntegral Int16
 instance DBIntegral Int32
 instance DBIntegral Int64


### PR DESCRIPTION
The functions in `Rel8.Expr.Num` that were called `div` and `mod` actually behaved like the Haskell functions `quot` and `rem` on negative values.