### PR TITLE
Export eqTable and ordTable

### DIFF
--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -46,8 +46,8 @@ module Rel8
   , Transposes
   , AltTable((<|>:))
   , AlternativeTable( emptyTable )
-  , EqTable, (==:), (/=:)
-  , OrdTable, (<:), (<=:), (>:), (>=:), ascTable, descTable, greatest, least
+  , EqTable(..), (==:), (/=:)
+  , OrdTable(..), (<:), (<=:), (>:), (>=:), ascTable, descTable, greatest, least
   , lit
   , bool
   , case_


### PR DESCRIPTION
These are necessary if one wants to define `EqTable` and `OrdTable` for a type which is not an instance of `Generic`.