### PR TITLE
Support `opaleye-0.9`

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -27,7 +27,7 @@ library
     , comonad
     , contravariant
     , hasql ^>= 1.4.5.1 || ^>= 1.5.0.0
-    , opaleye ^>= 0.8.0.0
+    , opaleye ^>= 0.9.0.0
     , pretty
     , profunctors
     , product-profunctors

--- a/src/Rel8/Expr/Opaleye.hs
+++ b/src/Rel8/Expr/Opaleye.hs
@@ -80,9 +80,9 @@ traversePrimExpr :: Functor f
 traversePrimExpr f = fmap fromPrimExpr . f . toPrimExpr
 
 
-toColumn :: Opaleye.PrimExpr -> Opaleye.Column b
+toColumn :: Opaleye.PrimExpr -> Opaleye.Field_ n b
 toColumn = Opaleye.Column
 
 
-fromColumn :: Opaleye.Column b -> Opaleye.PrimExpr
+fromColumn :: Opaleye.Field_ n b -> Opaleye.PrimExpr
 fromColumn (Opaleye.Column a) = a


### PR DESCRIPTION
This brings rel8 up to date with `opaleye-0.9`.