### PR TITLE
Correct the document for `Rel8.Query.Set`

### DIFF
--- a/src/Rel8/Query/Set.hs
+++ b/src/Rel8/Query/Set.hs
@@ -23,36 +23,36 @@ import Rel8.Table.Opaleye ( binaryspec )
 
 
 -- | Combine the results of two queries of the same type, collapsing
--- duplicates.  @union a b@ is the same as the SQL statement @x UNION b@.
+-- duplicates.  @union a b@ is the same as the SQL statement @a UNION b@.
 union :: EqTable a => Query a -> Query a -> Query a
 union = zipOpaleyeWith (Opaleye.unionExplicit binaryspec)
 
 
 -- | Combine the results of two queries of the same type, retaining duplicates.
--- @unionAll a b@ is the same as the SQL statement @x UNION ALL b@.
+-- @unionAll a b@ is the same as the SQL statement @a UNION ALL b@.
 unionAll :: Table Expr a => Query a -> Query a -> Query a
 unionAll = zipOpaleyeWith (Opaleye.unionAllExplicit binaryspec)
 
 
 -- | Find the intersection of two queries, collapsing duplicates.  @intersect a
--- b@ is the same as the SQL statement @x INTERSECT b@.
+-- b@ is the same as the SQL statement @a INTERSECT b@.
 intersect :: EqTable a => Query a -> Query a -> Query a
 intersect = zipOpaleyeWith (Opaleye.intersectExplicit binaryspec)
 
 
 -- | Find the intersection of two queries, retaining duplicates.  @intersectAll
--- a b@ is the same as the SQL statement @x INTERSECT ALL b@.
+-- a b@ is the same as the SQL statement @a INTERSECT ALL b@.
 intersectAll :: EqTable a => Query a -> Query a -> Query a
 intersectAll = zipOpaleyeWith (Opaleye.intersectAllExplicit binaryspec)
 
 
 -- | Find the difference of two queries, collapsing duplicates @except a b@ is
--- the same as the SQL statement @x EXCEPT b@.
+-- the same as the SQL statement @a EXCEPT b@.
 except :: EqTable a => Query a -> Query a -> Query a
 except = zipOpaleyeWith (Opaleye.exceptExplicit binaryspec)
 
 
 -- | Find the difference of two queries, retaining duplicates.  @exceptAll a b@
--- is the same as the SQL statement @x EXCEPT ALL b@.
+-- is the same as the SQL statement @a EXCEPT ALL b@.
 exceptAll :: EqTable a => Query a -> Query a -> Query a
 exceptAll = zipOpaleyeWith (Opaleye.exceptAllExplicit binaryspec)


### PR DESCRIPTION
All of these functions had documentation of the form `f x y` is like `a F y` (note that one mentions `x` and one mentions `a`).

Fixes #147.