### PR TITLE
Changes required for Opaleye 0.9.1.0

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -27,7 +27,7 @@ library
     , comonad
     , contravariant
     , hasql ^>= 1.4.5.1 || ^>= 1.5.0.0
-    , opaleye ^>= 0.9.0.0
+    , opaleye ^>= 0.9.1.0
     , pretty
     , profunctors
     , product-profunctors

--- a/src/Rel8/Query/Distinct.hs
+++ b/src/Rel8/Query/Distinct.hs
@@ -11,8 +11,8 @@ where
 import Prelude
 
 -- opaleye
-import qualified Opaleye.Distinct as Opaleye hiding ( distinctOn, distinctOnBy )
-import qualified Opaleye.Internal.Order as Opaleye
+import qualified Opaleye.Distinct as Opaleye
+import qualified Opaleye.Order as Opaleye
 import qualified Opaleye.Internal.QueryArr as Opaleye
 
 -- rel8
@@ -33,13 +33,11 @@ distinct = mapOpaleye (Opaleye.distinctExplicit distinctspec)
 -- to a projection. If multiple rows have the same projection, it is
 -- unspecified which row will be returned. If this matters, use 'distinctOnBy'.
 distinctOn :: EqTable b => (a -> b) -> Query a -> Query a
-distinctOn proj =
-  mapOpaleye (\q -> Opaleye.productQueryArr (Opaleye.distinctOn unpackspec proj . Opaleye.runSimpleQueryArr q))
+distinctOn proj = mapOpaleye (Opaleye.distinctOnExplicit unpackspec proj)
 
 
 -- | Select all distinct rows from a query, where rows are equivalent according
 -- to a projection. If there are multiple rows with the same projection, the
 -- first row according to the specified 'Order' will be returned.
 distinctOnBy :: EqTable b => (a -> b) -> Order a -> Query a -> Query a
-distinctOnBy proj (Order order) =
-  mapOpaleye (\q -> Opaleye.productQueryArr (Opaleye.distinctOnBy unpackspec proj order . Opaleye.runSimpleQueryArr q))
+distinctOnBy proj (Order order) = mapOpaleye (Opaleye.distinctOnByExplicit unpackspec proj order)

--- a/src/Rel8/Query/Rebind.hs
+++ b/src/Rel8/Query/Rebind.hs
@@ -7,29 +7,21 @@ where
 
 -- base
 import Prelude
+import Control.Arrow ((<<<))
 
 -- opaleye
-import qualified Opaleye.Internal.PackMap as Opaleye
-import qualified Opaleye.Internal.PrimQuery as Opaleye
-import qualified Opaleye.Internal.QueryArr as Opaleye
-import qualified Opaleye.Internal.Tag as Opaleye
-import qualified Opaleye.Internal.Unpackspec as Opaleye
+import qualified Opaleye.Internal.Rebind as Opaleye
 
 -- rel8
 import Rel8.Expr ( Expr )
-import Rel8.Query ( Query( Query ) )
+import Rel8.Query ( Query )
 import Rel8.Table ( Table )
 import Rel8.Table.Opaleye ( unpackspec )
+import Rel8.Query.Opaleye (fromOpaleye)
 
 
 -- | 'rebind' takes a variable name, some expressions, and binds each of them
 -- to a new variable in the SQL. The @a@ returned consists only of these
 -- variables. It's essentially a @let@ binding for Postgres expressions.
 rebind :: Table Expr a => String -> a -> Query a
-rebind prefix a = Query $ \_ -> Opaleye.QueryArr $ \(_, tag) ->
-  let
-    tag' = Opaleye.next tag
-    (a', bindings) = Opaleye.run $
-      Opaleye.runUnpackspec unpackspec (Opaleye.extractAttr prefix tag) a
-  in
-    ((mempty, a'), \_ -> Opaleye.Rebind True bindings, tag')
+rebind prefix a = fromOpaleye (Opaleye.rebindExplicitPrefix prefix unpackspec <<< pure a)

--- a/src/Rel8/Query/These.hs
+++ b/src/Rel8/Query/These.hs
@@ -48,11 +48,11 @@ import Rel8.Type.Tag ( EitherTag( IsLeft, IsRight ) )
 alignBy :: ()
   => (a -> b -> Expr Bool)
   -> Query a -> Query b -> Query (TheseTable Expr a b)
-alignBy condition = zipOpaleyeWith $ \left right -> Opaleye.QueryArr $ \i -> case i of
-  (_, tag) -> (tab, join', tag''')
+alignBy condition = zipOpaleyeWith $ \left right -> Opaleye.stateQueryArr $ \_ t -> case t of
+  tag -> (tab, Opaleye.PrimQueryArr join', tag''')
     where
-      (ma, left', tag') = Opaleye.runSimpleQueryArr (pure <$> left) ((), tag)
-      (mb, right', tag'') = Opaleye.runSimpleQueryArr (pure <$> right) ((), tag')
+      (ma, left', tag') = Opaleye.runStateQueryArr (pure <$> left) () tag
+      (mb, right', tag'') = Opaleye.runStateQueryArr (pure <$> right) () tag'
       MaybeTable hasHere a = ma
       MaybeTable hasThere b = mb
       (hasHere', lbindings) = Opaleye.run $ do
@@ -63,8 +63,8 @@ alignBy condition = zipOpaleyeWith $ \left right -> Opaleye.QueryArr $ \i -> cas
       join lateral = Opaleye.Join Opaleye.FullJoin on left'' right''
         where
           on = toPrimExpr $ condition (extract a) (extract b)
-          left'' = (lateral, Opaleye.Rebind True lbindings left')
-          right'' = (lateral, Opaleye.Rebind True rbindings right')
+          left'' = (lateral, Opaleye.toPrimQuery (left' <> Opaleye.aRebind lbindings))
+          right'' = (lateral, Opaleye.toPrimQuery (right' <> Opaleye.aRebind rbindings))
       ma' = MaybeTable hasHere' a
       mb' = MaybeTable hasThere' b
       tab = TheseTable {here = ma', there = mb'}

--- a/src/Rel8/Tabulate.hs
+++ b/src/Rel8/Tabulate.hs
@@ -69,9 +69,7 @@ import Control.Comonad ( extract )
 
 -- opaleye
 import qualified Opaleye.Aggregate as Opaleye
-import qualified Opaleye.Internal.Order as Opaleye
-import qualified Opaleye.Internal.QueryArr as Opaleye
-import qualified Opaleye.Order as Opaleye ( orderBy )
+import qualified Opaleye.Order as Opaleye ( orderBy, distinctOnExplicit )
 
 -- profunctors
 import Data.Profunctor ( dimap, lmap )
@@ -350,14 +348,7 @@ distinct (Tabulation f) = Tabulation $ \p ->
   case fst (unsafePeekQuery (f p)) of
     Nothing -> limit 1 (f p)
     Just _ ->
-      mapOpaleye
-        (\q ->
-          Opaleye.productQueryArr
-            ( Opaleye.distinctOn (key unpackspec) fst
-            . Opaleye.runSimpleQueryArr q
-            )
-        )
-        (f p)
+      mapOpaleye (Opaleye.distinctOnExplicit (key unpackspec) fst) (f p)
 
 
 -- | 'order' orders the /values/ of a 'Tabulation' within their


### PR DESCRIPTION
Opaleye 0.9.1.0 has fairly aggressive simplification of `QueryArr` internals. This PR is required for `rel8` to build against it (0.9.1.0 is not internals-compatible with 0.9.0.0).

I took the opportunity to expose the rebind and distinct things you need in Opaleye's public API, so they won't break in future internal-only changes.

(I'm not completely certain that https://github.com/circuithub/rel8/commit/c47317ea5b627a7366d018d4daf19d526e0d8f7d is correct. It doesn't seem to be tested. You can drop it if you find it's not correct. All the other commits are essential though.)