### PR TITLE
Add NullTable

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -66,6 +66,7 @@ library
     Rel8.Column.List
     Rel8.Column.Maybe
     Rel8.Column.NonEmpty
+    Rel8.Column.Null
     Rel8.Column.These
 
     Rel8.Expr
@@ -167,6 +168,7 @@ library
     Rel8.Table.Maybe
     Rel8.Table.Name
     Rel8.Table.NonEmpty
+    Rel8.Table.Null
     Rel8.Table.Nullify
     Rel8.Table.Opaleye
     Rel8.Table.Ord

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -107,6 +107,14 @@ module Rel8
   , catNonEmptyTable
   , catNonEmpty
 
+    -- ** @NullTable@
+  , NullTable
+  , nullableTable, nullTable, nullifyTable
+  , isNullTable, isNonNullTable
+  , catNullTable
+  , nameNullTable
+  , fromMaybeTable, toMaybeTable
+
     -- ** @ADT@
   , ADT, ADTable
   , BuildADT, buildADT
@@ -367,6 +375,7 @@ import Rel8.Table.List
 import Rel8.Table.Maybe
 import Rel8.Table.Name
 import Rel8.Table.NonEmpty
+import Rel8.Table.Null
 import Rel8.Table.Opaleye ( castTable )
 import Rel8.Table.Ord
 import Rel8.Table.Order

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -38,6 +38,7 @@ module Rel8
   , HMaybe
   , HList
   , HNonEmpty
+  , HNull
   , HThese
   , Lift
 
@@ -314,6 +315,7 @@ import Rel8.Column.Lift
 import Rel8.Column.List
 import Rel8.Column.Maybe
 import Rel8.Column.NonEmpty
+import Rel8.Column.Null
 import Rel8.Column.These
 import Rel8.Expr
 import Rel8.Expr.Aggregate

--- a/src/Rel8/Column/Null.hs
+++ b/src/Rel8/Column/Null.hs
@@ -1,0 +1,26 @@
+{-# language DataKinds #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeFamilyDependencies #-}
+
+module Rel8.Column.Null
+  ( HNull
+  )
+where
+
+-- base
+import Data.Kind ( Type )
+import Prelude
+
+-- rel8
+import qualified Rel8.Schema.Kind as K
+import Rel8.Schema.Result ( Result )
+import Rel8.Table.Null ( NullTable )
+
+
+-- | Nest a 'Null' value within a 'Rel8able'. @HNull f a@ will produce a
+-- 'NullTable' @a@ in the 'Expr' context, and a @'Maybe' a@ in the 'Result'
+-- context.
+type HNull :: K.Context -> Type -> Type
+type family HNull context = maybe | maybe -> context where
+  HNull Result = Maybe
+  HNull context = NullTable context

--- a/src/Rel8/Query/Null.hs
+++ b/src/Rel8/Query/Null.hs
@@ -1,5 +1,8 @@
+{-# language FlexibleContexts #-}
+
 module Rel8.Query.Null
   ( catNull
+  , catNullTable
   )
 where
 
@@ -9,6 +12,8 @@ import Prelude
 -- rel8
 import Rel8.Expr ( Expr )
 import Rel8.Expr.Null ( isNonNull, unsafeUnnullify )
+import Rel8.Table ( Table )
+import Rel8.Table.Null ( NullTable, isNonNullTable, unsafeUnnullifyTable )
 import Rel8.Query ( Query )
 import Rel8.Query.Filter ( where_ )
 
@@ -21,3 +26,13 @@ catNull :: Expr (Maybe a) -> Query (Expr a)
 catNull a = do
   where_ $ isNonNull a
   pure $ unsafeUnnullify a
+
+
+-- | Filter a 'Query' that might return @nullTable@ to a 'Query' without any
+-- @nullTable@s.
+--
+-- Corresponds to 'Data.Maybe.catMaybes'.
+catNullTable :: Table Expr a => NullTable Expr a -> Query a
+catNullTable a = do
+  where_ $ isNonNullTable a
+  pure $ unsafeUnnullifyTable a

--- a/src/Rel8/Table/Null.hs
+++ b/src/Rel8/Table/Null.hs
@@ -1,0 +1,135 @@
+{-# language DataKinds #-}
+{-# language FlexibleContexts #-}
+{-# language FlexibleInstances #-}
+{-# language MultiParamTypeClasses #-}
+{-# language ScopedTypeVariables #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeApplications #-}
+{-# language TypeFamilies #-}
+{-# language UndecidableInstances #-}
+
+module Rel8.Table.Null
+  ( NullTable(..)
+  , nullableTable, nullTable, nullifyTable, unsafeUnnullifyTable
+  , isNullTable, isNonNullTable
+  , nameNullTable
+  , toMaybeTable, fromMaybeTable
+  )
+where
+
+-- base
+import Data.Kind ( Type )
+import Prelude hiding ( null, undefined )
+
+-- comonad
+import Control.Comonad ( extract )
+
+-- rel8
+import Rel8.Expr ( Expr )
+import Rel8.Expr.Bool ( not_ )
+import Rel8.Kind.Context ( Reifiable )
+import qualified Rel8.Schema.Kind as K
+import Rel8.Schema.Name ( Name )
+import Rel8.Table
+  ( Table, Columns, Context, fromColumns, toColumns
+  , FromExprs, fromResult, toResult
+  , Transpose
+  )
+import Rel8.Table.Bool ( bool )
+import Rel8.Table.Eq ( EqTable, eqTable )
+import Rel8.Table.Maybe ( MaybeTable, justTable, maybeTable, nothingTable )
+import Rel8.Table.Nullify ( Nullify, isNull )
+import Rel8.Table.Ord ( OrdTable, ordTable )
+import Rel8.Table.Projection ( Projectable, project )
+import Rel8.Table.Serialize ( ToExprs )
+import Rel8.Table.Undefined ( undefined )
+
+
+-- | @NullTable t@ is the table @t@, but where all the columns in @t@ have the
+-- possibility of being 'Rel8.null'. This is very similar to
+-- 'Rel8.MaybeTable', except that it does not use an extra tag field, so it
+-- cannot distinguish between @Nothing@ and @Just Nothing@ if nested. In other
+-- words, if all of the columns of the @t@ passed to @NullTable@ are already
+-- nullable, then @NullTable@ has no effect.
+type NullTable :: K.Context -> Type -> Type
+newtype NullTable context a = NullTable (Nullify context a)
+
+
+instance Projectable (NullTable context) where
+  project f (NullTable a) = NullTable (project f a)
+
+
+instance (Table context a, Reifiable context, context ~ context') =>
+  Table context' (NullTable context a)
+ where
+  type Columns (NullTable context a) = Columns (Nullify context a)
+  type Context (NullTable context a) = Context (Nullify context a)
+  type FromExprs (NullTable context a) = FromExprs (Nullify context a)
+  type Transpose to (NullTable context a) = NullTable to (Transpose to a)
+
+  toColumns (NullTable a) = toColumns a
+  fromColumns = NullTable . fromColumns
+
+  toResult = toResult @_ @(Nullify context a)
+  fromResult = fromResult @_ @(Nullify context a)
+
+
+instance (EqTable a, context ~ Expr) => EqTable (NullTable context a) where
+  eqTable = eqTable @(Nullify context a)
+
+
+instance (OrdTable a, context ~ Expr) => OrdTable (NullTable context a) where
+  ordTable = ordTable @(Nullify context a)
+
+
+instance (ToExprs exprs a, context ~ Expr) =>
+  ToExprs (NullTable context exprs) (Maybe a)
+
+
+-- | Check if any of the non-nullable fields of @a@ are 'Rel8.null' under the
+-- 'NullTable'. Returns 'Rel8.false' if @a@ has no non-nullable fields.
+isNullTable :: Table Expr a => NullTable Expr a -> Expr Bool
+isNullTable (NullTable a) = isNull a
+
+
+-- | The inverse of 'isNullTable'.
+isNonNullTable :: Table Expr a => NullTable Expr a -> Expr Bool
+isNonNullTable = not_ . isNullTable
+
+
+-- | Like 'Rel8.nullable'.
+nullableTable :: (Table Expr a, Table Expr b)
+  => b -> (a -> b) -> NullTable Expr a -> b
+nullableTable b f ma@(NullTable a) = bool (f (extract a)) b (isNullTable ma)
+
+
+-- | The null table. Like 'Rel8.null'.
+nullTable :: Table Expr a => NullTable Expr a
+nullTable = NullTable (pure undefined)
+
+
+-- | Lift any table into 'NullTable'. Like 'Rel8.nullify'.
+nullifyTable :: a -> NullTable Expr a
+nullifyTable = NullTable . pure
+
+
+unsafeUnnullifyTable :: NullTable Expr a -> a
+unsafeUnnullifyTable (NullTable a) = extract a
+
+
+-- | Construct a 'NullTable' in the 'Name' context. This can be useful if you
+-- have a 'NullTable' that you are storing in a table and need to construct a
+-- 'TableSchema'.
+nameNullTable :: a -> NullTable Name a
+nameNullTable = NullTable . pure
+
+
+-- | Convert a 'NullTable' to a 'MaybeTable'.
+toMaybeTable :: Table Expr a => NullTable Expr a -> MaybeTable Expr a
+toMaybeTable = nullableTable nothingTable justTable
+
+
+-- | Convert a 'MaybeTable' to a 'NullTable'. Note that if the underlying @a@
+-- has no non-nullable fields, this is a lossy conversion.
+fromMaybeTable :: Table Expr a => MaybeTable Expr a -> NullTable Expr a
+fromMaybeTable = maybeTable nullTable nullifyTable


### PR DESCRIPTION
This is an alternative to `MaybeTable` that doesn't use a tag columns. It's less flexible (no `Functor` or `Applicative` instance) and is meaningless when used with a table that has no non-nullable columns (so nesting `NullTable` is redundant). But in situations where the underlying `Table` does have non-nullable columns, it can losslessly converted to and from `MaybeTable`.

It is useful for embedding into a base table when you don't want to store the extra tag column in your schema.