### PR TITLE
Fix `greatest` and `least`

### DIFF
--- a/src/Rel8/Table/Ord.hs
+++ b/src/Rel8/Table/Ord.hs
@@ -146,9 +146,9 @@ infix 4 >=:
 
 -- | Given two 'Table's, return the table that sorts before the other.
 least :: OrdTable a => a -> a -> a
-least a b = bool a b (a <: b)
+least a b = bool b a (a <: b)
 
 
 -- | Given two 'Table's, return the table that sorts after the other.
 greatest :: OrdTable a => a -> a -> a
-greatest a b = bool a b (a >: b)
+greatest a b = bool b a (a >: b)


### PR DESCRIPTION
`greatest` and `least` were unfortunately incorrect, their implementations were the wrong way around. `greatestExpr` and `leastExpr` were unaffected by this.