### PR TITLE
Use Opaleye adaptors

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -27,7 +27,7 @@ library
     , comonad
     , contravariant
     , hasql ^>= 1.4.5.1 || ^>= 1.5.0.0
-    , opaleye ^>= 0.9.1.0
+    , opaleye ^>= 0.9.3.3
     , pretty
     , profunctors
     , product-profunctors

--- a/src/Rel8/Expr/Opaleye.hs
+++ b/src/Rel8/Expr/Opaleye.hs
@@ -10,7 +10,7 @@ module Rel8.Expr.Opaleye
   , scastExpr, sunsafeCastExpr
   , unsafeLiteral
   , fromPrimExpr, toPrimExpr, mapPrimExpr, zipPrimExprsWith, traversePrimExpr
-  , toColumn, fromColumn
+  , toColumn, fromColumn, traverseFieldP
   )
 where
 
@@ -26,6 +26,9 @@ import {-# SOURCE #-} Rel8.Expr ( Expr( Expr ) )
 import Rel8.Schema.Null ( Unnullify, Sql )
 import Rel8.Type ( DBType, typeInformation )
 import Rel8.Type.Information ( TypeInformation(..) )
+
+-- profunctors
+import Data.Profunctor ( Profunctor, dimap )
 
 
 castExpr :: Sql DBType a => Expr a -> Expr a
@@ -78,6 +81,12 @@ zipPrimExprsWith f a b = fromPrimExpr (f (toPrimExpr a) (toPrimExpr b))
 traversePrimExpr :: Functor f
   => (Opaleye.PrimExpr -> f Opaleye.PrimExpr) -> Expr a -> f (Expr b)
 traversePrimExpr f = fmap fromPrimExpr . f . toPrimExpr
+
+
+traverseFieldP :: Profunctor p
+  => p (Opaleye.Field_ n x) (Opaleye.Field_ m y)
+  -> p (Expr a) (Expr b)
+traverseFieldP =  dimap (toColumn . toPrimExpr) (fromPrimExpr . fromColumn)
 
 
 toColumn :: Opaleye.PrimExpr -> Opaleye.Field_ n b

--- a/src/Rel8/Schema/HTable.hs
+++ b/src/Rel8/Schema/HTable.hs
@@ -32,6 +32,12 @@ import GHC.Generics
   )
 import Prelude
 
+-- profunctors
+import Data.Profunctor ( rmap, Profunctor (lmap) )
+
+-- product-profunctors
+import Data.Profunctor.Product ( ProductProfunctor ((****)) )
+
 -- rel8
 import Rel8.Schema.Dict ( Dict )
 import Rel8.Schema.Spec ( Spec )
@@ -40,11 +46,6 @@ import qualified Rel8.Schema.Kind as K
 
 -- semigroupoids
 import Data.Functor.Apply ( Apply, (<.>) )
-
--- (product-)profunctors
-import Data.Profunctor.Product ( ProductProfunctor ((****)) )
-import Data.Profunctor ( rmap, Profunctor (lmap) )
-
 
 -- | A @HTable@ is a functor-indexed/higher-kinded data type that is
 -- representable ('htabulate'/'hfield'), constrainable ('hdicts'), and

--- a/src/Rel8/Schema/HTable.hs
+++ b/src/Rel8/Schema/HTable.hs
@@ -16,7 +16,7 @@
 module Rel8.Schema.HTable
   ( HTable (HField, HConstrainTable)
   , hfield, htabulate, htraverse, hdicts, hspecs
-  , hmap, htabulateA, htraverseP
+  , hmap, htabulateA, htraverseP, htraversePWithField
   )
 where
 
@@ -138,8 +138,12 @@ instance ProductProfunctor p => Apply (ApplyP p a) where
 
 htraverseP :: (HTable t, ProductProfunctor p)
   => (forall a. p (f a) (g a)) -> p (t f) (t g)
-htraverseP f = unApplyP $ htabulateA $ \field -> ApplyP $
-  lmap (flip hfield field) f
+htraverseP f = htraversePWithField (const f)
+
+htraversePWithField :: (HTable t, ProductProfunctor p)
+  => (forall a. HField t a -> p (f a) (g a)) -> p (t f) (t g)
+htraversePWithField f = unApplyP $ htabulateA $ \field -> ApplyP $
+  lmap (flip hfield field) (f field)
 
 type GHField :: K.HTable -> Type -> Type
 newtype GHField t a = GHField (HField (GHColumns (Rep (t Proxy))) a)

--- a/src/Rel8/Table/Opaleye.hs
+++ b/src/Rel8/Table/Opaleye.hs
@@ -63,11 +63,9 @@ import Data.Profunctor.Product ( ProductProfunctor )
 
 
 aggregator :: Aggregates aggregates exprs => Opaleye.Aggregator aggregates exprs
-aggregator = Opaleye.Aggregator $ Opaleye.PackMap $ \f aggregates ->
-  fmap fromColumns $ unwrapApplicative $ htabulateA $ \field ->
-    WrapApplicative $ case hfield (toColumns aggregates) field of
-      Aggregate (Opaleye.Aggregator (Opaleye.PackMap inner)) ->
-        inner f ()
+aggregator = dimap toColumns fromColumns $
+             htraverseP $
+             lmap (\(Aggregate a) -> (a, ())) Opaleye.aggregatorApply
 
 
 attributes :: Selects names exprs => TableSchema names -> exprs

--- a/src/Rel8/Table/Opaleye.hs
+++ b/src/Rel8/Table/Opaleye.hs
@@ -48,7 +48,6 @@ import Rel8.Expr ( Expr )
 import Rel8.Expr.Opaleye
   ( fromPrimExpr, toPrimExpr
   , traversePrimExpr
-  , fromColumn, toColumn
   , scastExpr, traverseFieldP
   )
 import Rel8.Schema.HTable ( htabulateA, hfield, htraverse, hspecs, htabulate,
@@ -124,7 +123,7 @@ tableFields (toColumns -> names) = dimap toColumns fromColumns $
   where
     go :: Name a -> Opaleye.TableFields (Expr a) (Expr a)
     go (Name name) =
-      dimap (toColumn . toPrimExpr) (fromPrimExpr . fromColumn) $
+      traverseFieldP $
         Opaleye.requiredTableField name
 
 


### PR DESCRIPTION
This is part of my ongoing quest to reduce the amount of Opaleye internals that Rel8 depends on.

* `htraverseP` seems generally useful and worth including regardless, if you want Rel8 to play well with the `ProductProfunctors` ecosystem.
* ~`htraversePType` is `Table`-specific. I'm not sure which module it should go in.~ EDIT: I changed the implementation so this doesn't exist any more.

----

Important note: I'm about to land [a fairly big refactoring to `Opaleye.Internal.Values`](https://github.com/tomjaguarpaw/haskell-opaleye/compare/master...values) (https://github.com/tomjaguarpaw/haskell-opaleye/commit/a7384fde097f6abf66fce17abfb122b3f26a00bb) which will break Rel8 `master` but is compatible with Rel8 post this PR.
