### PR TITLE
Use less Opaleye internals in aggregation

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -27,7 +27,7 @@ library
     , comonad
     , contravariant
     , hasql ^>= 1.4.5.1 || ^>= 1.5.0.0 || ^>= 1.6.0.0
-    , opaleye ^>= 0.9.3.3
+    , opaleye ^>= 0.9.6.1
     , pretty
     , profunctors
     , product-profunctors


### PR DESCRIPTION
Would it be OK to do this, to depend on less Opaleye internals?