### PR TITLE
Fix insertion of default values

### DIFF
--- a/src/Rel8/Statement/Select.hs
+++ b/src/Rel8/Statement/Select.hs
@@ -19,7 +19,6 @@ where
 -- base
 import Data.Foldable ( toList )
 import Data.Kind ( Type )
-import Data.List.NonEmpty ( NonEmpty( (:|) ) )
 import Data.Void ( Void )
 import Prelude hiding ( undefined )
 
@@ -92,7 +91,7 @@ ppSelect query =
 ppRows :: Table Expr a => Query a -> Doc
 ppRows query = case optimize primQuery of
   -- Special case VALUES because we can't use DEFAULT inside a SELECT
-  Optimized (Opaleye.Product ((_, Opaleye.Values symbols rows) :| []) [])
+  Optimized (Opaleye.Values symbols rows)
     | eqSymbols symbols (toList (T.exprs a)) ->
         Opaleye.ppValues_ (map Opaleye.sqlExpr <$> toList rows)
   _ -> ppSelect query
@@ -120,7 +119,7 @@ ppPrimSelect query =
 
 type Optimized :: Type -> Type
 data Optimized a = Empty | Unit | Optimized a
-  deriving stock (Functor, Foldable, Traversable)
+  deriving stock (Functor, Foldable, Traversable, Show)
 
 
 optimize :: Opaleye.PrimQuery' a -> Optimized (Opaleye.PrimQuery' Void)


### PR DESCRIPTION
At some point, possibly due to a change in Opaleye, insertion of default values (using `unsafeDefault`) stopped working in Rel8.

In general, PostgreSQL only allows insertion of default values in insert statements that have the form `INSERT INTO table VALUES (DEFAULT)`. The way Opaleye typically generates SQL, the Rel8 equivalent to that code would come out looking more like `INSERT INTO table SELECT * FROM (VALUES (DEFAULT)) q`. Because the `VALUES` is wrapped in a `SELECT`, the `DEFAULT` becomes invalud PostgreSQL syntax.

To get around this, we special case `VALUES` when generating SQL for INSERT statements. However, something in the Opaleye representation changed and this special case was no longer firing. This commit fixes that.