### PR TITLE
Restore zero-based `indexed`

### DIFF
--- a/src/Rel8/Query/Indexed.hs
+++ b/src/Rel8/Query/Indexed.hs
@@ -6,7 +6,7 @@ where
 -- base
 import Control.Applicative ( liftA2 )
 import Data.Int ( Int64 )
-import Prelude ()
+import Prelude
 
 -- rel8
 import Rel8.Expr ( Expr )
@@ -18,4 +18,4 @@ import Rel8.Table.Window ( currentRow )
 
 -- | Pair each row of a query with its index within the query.
 indexed :: Query a -> Query (Expr Int64, a)
-indexed = window (liftA2 (,) rowNumber currentRow)
+indexed = window (liftA2 (,) (subtract 1 <$> rowNumber) currentRow)


### PR DESCRIPTION
In #182 we introduced window functions, and also refactored `indexed` to use the new window function support via `rowNumber`.

However, previously `indexed` was zero-based, whereas PostgreSQL's `row_number()` function counts from one, so this change silently changed the behaviour of `indexed`.

This commit restores the previous behaviour.