### PR TITLE
Call `quote_ident` before `nextval`

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,6 +1,6 @@
 let
   sources = import ./nix/sources.nix;
-  pkgs = import sources.nixpkgs {};
+  pkgs = import sources.nixpkgs {overlays = [];};
   hsPkgs = import ./default.nix;
 in
   hsPkgs.shellFor {

--- a/src/Rel8/Expr/Sequence.hs
+++ b/src/Rel8/Expr/Sequence.hs
@@ -11,6 +11,7 @@ import Prelude
 import Rel8.Expr ( Expr )
 import Rel8.Expr.Function ( function )
 import Rel8.Expr.Serialize ( litExpr )
+import Rel8.Expr.Text ( quoteIdent )
 
 -- text
 import Data.Text ( pack )
@@ -18,4 +19,4 @@ import Data.Text ( pack )
 
 -- | See https://www.postgresql.org/docs/current/functions-sequence.html
 nextval :: String -> Expr Int64
-nextval = function "nextval" . litExpr . pack
+nextval = function "nextval" . quoteIdent . litExpr . pack


### PR DESCRIPTION
It turns out you can't do `nextval('FooBar_id_seq')` in PostgreSQL, you need to write `nextval('"FooBar_id_seq"')`.