### PR TITLE
Fixes CASE/WHEN expression possibly returning a set

### DIFF
--- a/src/Rel8/Table/Maybe.hs
+++ b/src/Rel8/Table/Maybe.hs
@@ -142,7 +142,7 @@ instance (Table context a, Reifiable context, context ~ context') =>
 
   toColumns MaybeTable {tag, just} = HMaybeTable
     { htag = hlabel $ HIdentity tag
-    , hjust = hlabel $ guard tag isJust isNonNull $ toColumns just
+    , hjust = hlabel $ toColumns just
     }
 
   fromColumns HMaybeTable {htag, hjust} = MaybeTable


### PR DESCRIPTION
closes #219

From what I understand the problem was that `boolExpr` was being called directly with a value of "UNNEST(.." which directly produces a set which is then returned in the body of a `CASE/WHEN` expression.

If you try to create the same problem with publicly exported functions (using `maybeTable` for example which call `boolExpr` internally) then you are forced to `>>=` the `UNNEST`ed rows which results in a subexpression in SQL and the `CASE/WHEN` ends up returning a single row instead of a set.

`MaybeTable` used to use `guard` which woks around the requirement of an extra `>>=`. The fix just removes the `tag` check for the `just` column altogether. This seems fine to me because ~~there can never be a case where `tag` is non-null and `just` is null. I e it seems like the `guard` was redundant.~~