### PR TITLE
Add inet DBType

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -27,6 +27,7 @@ library
     , comonad
     , contravariant
     , hasql ^>= 1.4.5.1 || ^>= 1.5.0.0 || ^>= 1.6.0.0
+    , network-ip
     , opaleye ^>= 0.9.6.1
     , pretty
     , profunctors
@@ -216,6 +217,7 @@ test-suite tests
     , hasql-transaction
     , hedgehog          ^>= 1.0 || ^>= 1.1
     , mmorph
+    , network-ip
     , rel8
     , scientific
     , tasty

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -213,6 +213,7 @@ test-suite tests
     , bytestring
     , case-insensitive
     , containers
+    , data-dword
     , hasql
     , hasql-transaction
     , hedgehog          ^>= 1.0 || ^>= 1.1

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -26,7 +26,7 @@ library
     , case-insensitive
     , comonad
     , contravariant
-    , hasql ^>= 1.4.5.1 || ^>= 1.5.0.0 || ^>= 1.6.0.0
+    , hasql ^>= 1.6.1.2
     , network-ip
     , opaleye ^>= 0.9.6.1
     , pretty

--- a/src/Rel8/Type.hs
+++ b/src/Rel8/Type.hs
@@ -65,6 +65,8 @@ import Data.Time.Format ( formatTime, defaultTimeLocale )
 import Data.UUID ( UUID )
 import qualified Data.UUID as UUID
 
+-- ip
+import Network.IP.Addr (NetAddr, IP, printNetAddr)
 
 -- | Haskell types that can be represented as expressions in a database. There
 -- should be an instance of @DBType@ for all column types in your database
@@ -277,6 +279,15 @@ instance DBType Value where
         Lazy.unpack . Lazy.decodeUtf8 . Aeson.encode
     , decode = Hasql.jsonb
     , typeName = "jsonb"
+    }
+
+-- | Corresponds to @inet@
+instance DBType (NetAddr IP) where
+  typeInformation = TypeInformation
+    { encode =
+        Opaleye.ConstExpr . Opaleye.StringLit . printNetAddr
+    , decode = Hasql.inet
+    , typeName = "inet"
     }
 
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -435,7 +435,7 @@ testDBType getTestDatabase = testGroup "DBType instances"
     dbTypeTest :: (Eq a, Show a, Rel8.DBType a) => TestName -> Gen a -> TestTree
     dbTypeTest name generator = testGroup name
       [ databasePropertyTest name (t generator) getTestDatabase
-      , databasePropertyTest ("Maybe " <> name) (t (Gen.maybe generator int)) getTestDatabase
+      , databasePropertyTest ("Maybe " <> name) (t (Gen.maybe generator)) getTestDatabase
       ]
 
     t :: forall a b. (Eq a, Show a, Rel8.Sql Rel8.DBType a)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -89,6 +89,7 @@ import qualified Data.UUID
 
 -- ip
 import Network.IP.Addr (NetAddr(..), IP(..), IP4(..), IP6(..))
+import Data.DoubleWord (Word128(..))
 
 main :: IO ()
 main = defaultMain tests

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -478,20 +478,20 @@ testDBType getTestDatabase = testGroup "DBType instances"
 
     genNetAddrIP  :: Gen (NetAddr IP)
     genNetAddrIP =
-      let genIP4Mask :: Gen Word8
-          genIP4Mask = Gen.integral (Range.linearFrom 0 0 32)
+      let
+        genIP4Mask :: Gen Word8
+        genIP4Mask = Gen.integral (Range.linearFrom 0 0 32)
 
-          genIPv4 :: Gen (IP46 Net4Addr Net6Addr)
-          genIPv4 = IPv4 <$> (liftA2 net4Addr (IP4 <$> genWord32) genIP4Mask)
+        genIPv4 :: Gen (IP46 Net4Addr Net6Addr)
+        genIPv4 = IPv4 <$> (liftA2 net4Addr (IP4 <$> genWord32) genIP4Mask)
 
-          genIP6Mask :: Gen Word8
-          genIP6Mask = Gen.integral (Range.linearFrom 0 0 128)
+        genIP6Mask :: Gen Word8
+        genIP6Mask = Gen.integral (Range.linearFrom 0 0 128)
 
-          genIPv6 :: Gen (IP46 Net4Addr Net6Addr)
-          genIPv6 = IPv6 <$> (liftA2 net6Addr (IP6 <$> genWord128) genIP6Mask)
-       in fromNetAddr46 <$> Gen.choice [ genIPv4
-                                       , genIPv6
-                                       ]
+        genIPv6 :: Gen (IP46 Net4Addr Net6Addr)
+        genIPv6 = IPv6 <$> (liftA2 net6Addr (IP6 <$> genWord128) genIP6Mask)
+
+       in fromNetAddr46 <$> Gen.choice [ genIPv4, genIPv6 ]
 
 
 testDBEq :: IO TmpPostgres.DB -> TestTree


### PR DESCRIPTION
This PR adds a DBType instance for `NetAddr IP`, which is the default type that hasql uses for the postgres `inet` type. In the future I would also like to add support for `SockAddr` from the `network` package.

I'm a new committer and would appreciate any feedback, especially nitpicks and stylistic comments.

As a side note, I was wondering if you have a public nix cache. I am trying to set up my dev environment to test, but haskell.nix is trying to rebuild the world!