### PR TITLE
Fix warnings on latest GHC

### DIFF
--- a/src/Rel8/Expr/Function.hs
+++ b/src/Rel8/Expr/Function.hs
@@ -3,6 +3,7 @@
 {-# language MultiParamTypeClasses #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Expr.Function

--- a/src/Rel8/Generic/Construction.hs
+++ b/src/Rel8/Generic/Construction.hs
@@ -7,6 +7,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 {-# language ViewPatterns #-}
 

--- a/src/Rel8/Schema/Null.hs
+++ b/src/Rel8/Schema/Null.hs
@@ -7,6 +7,7 @@
 {-# language RankNTypes #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 {-# language UndecidableSuperClasses #-}
 

--- a/src/Rel8/Statement/OnConflict.hs
+++ b/src/Rel8/Statement/OnConflict.hs
@@ -6,6 +6,7 @@
 {-# language RecordWildCards #-}
 {-# language StandaloneKindSignatures #-}
 {-# language StrictData #-}
+{-# language TypeOperators #-}
 
 module Rel8.Statement.OnConflict
   ( OnConflict(..)

--- a/src/Rel8/Table.hs
+++ b/src/Rel8/Table.hs
@@ -8,6 +8,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table

--- a/src/Rel8/Table/Cols.hs
+++ b/src/Rel8/Table/Cols.hs
@@ -3,6 +3,7 @@
 {-# language MultiParamTypeClasses #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.Cols

--- a/src/Rel8/Table/Either.hs
+++ b/src/Rel8/Table/Either.hs
@@ -10,6 +10,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 {-# options_ghc -fno-warn-orphans #-}

--- a/src/Rel8/Table/HKD.hs
+++ b/src/Rel8/Table/HKD.hs
@@ -8,6 +8,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 {-# language UndecidableSuperClasses #-}
 

--- a/src/Rel8/Table/List.hs
+++ b/src/Rel8/Table/List.hs
@@ -7,6 +7,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.List

--- a/src/Rel8/Table/Maybe.hs
+++ b/src/Rel8/Table/Maybe.hs
@@ -9,6 +9,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.Maybe

--- a/src/Rel8/Table/NonEmpty.hs
+++ b/src/Rel8/Table/NonEmpty.hs
@@ -7,6 +7,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.NonEmpty

--- a/src/Rel8/Table/Null.hs
+++ b/src/Rel8/Table/Null.hs
@@ -6,6 +6,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.Null

--- a/src/Rel8/Table/Nullify.hs
+++ b/src/Rel8/Table/Nullify.hs
@@ -8,6 +8,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.Nullify

--- a/src/Rel8/Table/Rel8able.hs
+++ b/src/Rel8/Table/Rel8able.hs
@@ -5,6 +5,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 {-# options_ghc -fno-warn-orphans #-}
@@ -15,6 +16,7 @@ module Rel8.Table.Rel8able
 where
 
 -- base
+import Data.Type.Equality (type (~))
 import Prelude ()
 
 -- rel8

--- a/src/Rel8/Table/Serialize.hs
+++ b/src/Rel8/Table/Serialize.hs
@@ -7,6 +7,7 @@
 {-# language StandaloneKindSignatures #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.Serialize

--- a/src/Rel8/Table/These.hs
+++ b/src/Rel8/Table/These.hs
@@ -10,6 +10,7 @@
 {-# language TupleSections #-}
 {-# language TypeApplications #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 {-# options_ghc -fno-warn-orphans #-}

--- a/src/Rel8/Table/Transpose.hs
+++ b/src/Rel8/Table/Transpose.hs
@@ -3,6 +3,7 @@
 {-# language FunctionalDependencies #-}
 {-# language StandaloneKindSignatures #-}
 {-# language TypeFamilies #-}
+{-# language TypeOperators #-}
 {-# language UndecidableInstances #-}
 
 module Rel8.Table.Transpose
@@ -12,6 +13,7 @@ where
 
 -- base
 import Data.Kind ( Constraint, Type )
+import Data.Type.Equality (type (~))
 import Prelude ()
 
 -- rel8


### PR DESCRIPTION
These are due to `~` no longer being built-in syntax.