### PR TITLE
Fix build on GHC 9.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,19 +4,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.3.4
+    - uses: actions/checkout@v3
       with:
           persist-credentials: false
           submodules: true
 
-    - uses: cachix/install-nix-action@v14.1
+    - uses: cachix/install-nix-action@v20
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
           trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
           substituters = https://cache.nixos.org/ https://cache.iog.io
 
-    - uses: cachix/cachix-action@v10
+    - uses: cachix/cachix-action@v12
       with:
         name: rel8
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/src/Rel8/Table/Rel8able.hs
+++ b/src/Rel8/Table/Rel8able.hs
@@ -1,3 +1,4 @@
+{-# language CPP #-}
 {-# language DataKinds #-}
 {-# language FlexibleInstances #-}
 {-# language MultiParamTypeClasses #-}
@@ -16,7 +17,9 @@ module Rel8.Table.Rel8able
 where
 
 -- base
+#if __GLASGOW_HASKELL__ >= 904
 import Data.Type.Equality (type (~))
+#endif
 import Prelude ()
 
 -- rel8

--- a/src/Rel8/Table/Transpose.hs
+++ b/src/Rel8/Table/Transpose.hs
@@ -1,3 +1,4 @@
+{-# language CPP #-}
 {-# language DataKinds #-}
 {-# language FlexibleInstances #-}
 {-# language FunctionalDependencies #-}
@@ -13,7 +14,9 @@ where
 
 -- base
 import Data.Kind ( Constraint, Type )
+#if __GLASGOW_HASKELL__ >= 904
 import Data.Type.Equality (type (~))
+#endif
 import Prelude ()
 
 -- rel8


### PR DESCRIPTION
PR #229 broke on GHC versions before 9.4 because `~` was not exported from `Data.Type.Equality` then.