### PR TITLE
Support nested `catListTable` (by representing nested arrays as text)

### DIFF
--- a/changelog.d/20230707_185221_ollie_scriv.md
+++ b/changelog.d/20230707_185221_ollie_scriv.md
@@ -1,3 +1,7 @@
 ### Fixed
 
-- A partial fix for nesting `catListTable`. The underlying issue in [#168](https://github.com/circuithub/rel8/issues/168) is still present, but we've made a bit of progress to reduce when this bug can happen. ([#243](https://github.com/circuithub/rel8/pull/243))
+- A fix for [#168](https://github.com/circuithub/rel8/issues/168), which prevented using `catListTable` on arrays of arrays. To achieve this we had to coerce arrays of arrays to text internally, which unfortunately isn't completely transparent; you can oberve it if you write something like `listTable [listTable [10]] > listTable [listTable [9]]`: previously that would be `false`, but now it's `true`. Arrays of non-arrays are unaffected by this.
+
+### Changed
+
+- `TypeInformation`'s `decoder` field has changed. Instead of taking a `Hasql.Decoder`, it now takes a `Rel8.Decoder`, which itself is comprised of a `Hasql.Decoder` and an `attoparsec` `Parser`. This is necessitated by the fix for [#168](https://github.com/circuithub/rel8/issues/168); we generally decode things in PostgreSQL's binary format (using a `Hasql.Decoder`), but for nested arrays we now get things in PostgreSQL's text format (for which we need an `attoparsec` `Parser`), so must have both. Most `DBType` instances that use `mapTypeInformation` or `ParseTypeInformation`, or `DerivingVia` helpers like `ReadShow`, `JSONBEncoded`, `Enum` and `Composite` are unaffected by this change.

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -20,13 +20,16 @@ source-repository head
 library
   build-depends:
       aeson
+    , attoparsec
     , base ^>= 4.14 || ^>=4.15 || ^>=4.16 || ^>=4.17
+    , base16 >= 1.0
     , base-compat ^>= 0.11 || ^>= 0.12 || ^>= 0.13
     , bifunctors
     , bytestring
     , case-insensitive
     , comonad
     , contravariant
+    , data-textual
     , hasql ^>= 1.6.1.2
     , network-ip
     , opaleye ^>= 0.10.0.0
@@ -40,8 +43,10 @@ library
     , these
     , time
     , transformers
+    , utf8-string
     , uuid
     , vector
+
   default-language:
     Haskell2010
   ghc-options:
@@ -201,6 +206,7 @@ library
     Rel8.Type
     Rel8.Type.Array
     Rel8.Type.Composite
+    Rel8.Type.Decoder
     Rel8.Type.Eq
     Rel8.Type.Enum
     Rel8.Type.Information
@@ -210,6 +216,9 @@ library
     Rel8.Type.Name
     Rel8.Type.Num
     Rel8.Type.Ord
+    Rel8.Type.Parser
+    Rel8.Type.Parser.ByteString
+    Rel8.Type.Parser.Time
     Rel8.Type.ReadShow
     Rel8.Type.Semigroup
     Rel8.Type.String

--- a/src/Rel8/Expr/Serialize.hs
+++ b/src/Rel8/Expr/Serialize.hs
@@ -23,6 +23,7 @@ import {-# SOURCE #-} Rel8.Expr ( Expr( Expr ) )
 import Rel8.Expr.Opaleye ( scastExpr )
 import Rel8.Schema.Null ( Unnullify, Nullity( Null, NotNull ), Sql, nullable )
 import Rel8.Type ( DBType, typeInformation )
+import Rel8.Type.Decoder (Decoder (..))
 import Rel8.Type.Information ( TypeInformation(..) )
 
 
@@ -44,6 +45,6 @@ slitExpr nullity info@TypeInformation {encode} =
 
 
 sparseValue :: Nullity a -> TypeInformation (Unnullify a) -> Hasql.Row a
-sparseValue nullity TypeInformation {decode} = case nullity of
-  Null -> Hasql.column $ Hasql.nullable decode
-  NotNull -> Hasql.column $ Hasql.nonNullable decode
+sparseValue nullity TypeInformation {decode = Decoder {binary}} = case nullity of
+  Null -> Hasql.column $ Hasql.nullable binary
+  NotNull -> Hasql.column $ Hasql.nonNullable binary

--- a/src/Rel8/Type.hs
+++ b/src/Rel8/Type.hs
@@ -1,3 +1,4 @@
+{-# language LambdaCase #-}
 {-# language FlexibleContexts #-}
 {-# language FlexibleInstances #-}
 {-# language MonoLocalBinds #-}
@@ -14,15 +15,21 @@ where
 -- aeson
 import Data.Aeson ( Value )
 import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Parser as Aeson
+
+-- attoparsec
+import qualified Data.Attoparsec.ByteString.Char8 as A
 
 -- base
+import Control.Applicative ((<|>))
 import Data.Int ( Int16, Int32, Int64 )
 import Data.List.NonEmpty ( NonEmpty )
 import Data.Kind ( Constraint, Type )
 import Prelude
 
 -- bytestring
-import Data.ByteString ( ByteString )
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as Lazy ( ByteString )
 import qualified Data.ByteString.Lazy as ByteString ( fromStrict, toStrict )
 
@@ -30,8 +37,14 @@ import qualified Data.ByteString.Lazy as ByteString ( fromStrict, toStrict )
 import Data.CaseInsensitive ( CI )
 import qualified Data.CaseInsensitive as CI
 
+-- data-textual
+import Data.Textual (textual)
+
 -- hasql
 import qualified Hasql.Decoders as Hasql
+
+-- network-ip
+import qualified Network.IP.Addr as IP
 
 -- opaleye
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
@@ -40,8 +53,12 @@ import qualified Opaleye.Internal.HaskellDB.Sql.Default as Opaleye ( quote )
 -- rel8
 import Rel8.Schema.Null ( NotNull, Sql, nullable )
 import Rel8.Type.Array ( listTypeInformation, nonEmptyTypeInformation )
+import Rel8.Type.Decoder ( Decoder(..) )
 import Rel8.Type.Information ( TypeInformation(..), mapTypeInformation )
 import Rel8.Type.Name (TypeName (..))
+import Rel8.Type.Parser (parse)
+import Rel8.Type.Parser.ByteString (bytestring)
+import qualified Rel8.Type.Parser.Time as Time
 
 -- scientific
 import Data.Scientific ( Scientific )
@@ -49,26 +66,28 @@ import Data.Scientific ( Scientific )
 -- text
 import Data.Text ( Text )
 import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text (decodeUtf8)
 import qualified Data.Text.Lazy as Lazy ( Text, unpack )
 import qualified Data.Text.Lazy as Text ( fromStrict, toStrict )
 import qualified Data.Text.Lazy.Encoding as Lazy ( decodeUtf8 )
 
 -- time
-import Data.Time.Calendar ( Day )
-import Data.Time.Clock ( UTCTime )
+import Data.Time.Calendar (Day)
+import Data.Time.Clock (UTCTime)
 import Data.Time.LocalTime
-  ( CalendarDiffTime( CalendarDiffTime )
+  ( CalendarDiffTime (CalendarDiffTime)
   , LocalTime
   , TimeOfDay
   )
-import Data.Time.Format ( formatTime, defaultTimeLocale )
+import Data.Time.Format (formatTime, defaultTimeLocale)
+
+-- utf8
+import qualified Data.ByteString.UTF8 as UTF8
 
 -- uuid
 import Data.UUID ( UUID )
 import qualified Data.UUID as UUID
 
--- ip
-import Network.IP.Addr (NetAddr, IP, printNetAddr)
 
 -- | Haskell types that can be represented as expressions in a database. There
 -- should be an instance of @DBType@ for all column types in your database
@@ -87,7 +106,15 @@ class NotNull a => DBType a where
 instance DBType Bool where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.BoolLit
-    , decode = Hasql.bool
+    , decode =
+        Decoder
+          { binary = Hasql.bool
+          , parser = \case
+              "t" -> pure True
+              "f" -> pure False
+              input -> Left $ "bool: bad bool " <> show input
+          , delimiter = ','
+          }
     , typeName = "bool"
     }
 
@@ -96,12 +123,19 @@ instance DBType Bool where
 instance DBType Char where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.StringLit . pure
-    , decode = Hasql.char
     , typeName =
         TypeName
           { name = "bpchar"
           , modifiers = ["1"]
           , arrayDepth = 0
+          }
+    , decode = 
+        Decoder
+          { binary = Hasql.char
+          , parser = \input -> case UTF8.uncons input of
+              Just (char, rest) | BS.null rest -> pure char
+              _ -> Left $ "char: bad char " <> show input
+          , delimiter = ','
           }
     }
 
@@ -110,7 +144,12 @@ instance DBType Char where
 instance DBType Int16 where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.IntegerLit . toInteger
-    , decode = Hasql.int2
+    , decode =
+        Decoder
+          { binary = Hasql.int2
+          , parser = parse (A.signed A.decimal)
+          , delimiter = ','
+          }
     , typeName = "int2"
     }
 
@@ -119,7 +158,12 @@ instance DBType Int16 where
 instance DBType Int32 where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.IntegerLit . toInteger
-    , decode = Hasql.int4
+    , decode =
+        Decoder
+          { binary = Hasql.int4
+          , parser = parse (A.signed A.decimal)
+          , delimiter = ','
+          }
     , typeName = "int4"
     }
 
@@ -128,7 +172,12 @@ instance DBType Int32 where
 instance DBType Int64 where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.IntegerLit . toInteger
-    , decode = Hasql.int8
+    , decode =
+        Decoder
+          { binary = Hasql.int8
+          , parser = parse (A.signed A.decimal)
+          , delimiter = ','
+          }
     , typeName = "int8"
     }
 
@@ -141,7 +190,12 @@ instance DBType Float where
            | isNaN x       -> Opaleye.OtherLit "'NaN'"
            | x == (-1 / 0) -> Opaleye.OtherLit "'-Infinity'"
            | otherwise     -> Opaleye.NumericLit $ realToFrac x
-    , decode = Hasql.float4
+    , decode =
+        Decoder
+          { binary = Hasql.float4
+          , parser = parse (floating (realToFrac <$> A.double))
+          , delimiter = ','
+          }
     , typeName = "float4"
     }
 
@@ -154,7 +208,12 @@ instance DBType Double where
            | isNaN x       -> Opaleye.OtherLit "'NaN'"
            | x == (-1 / 0) -> Opaleye.OtherLit "'-Infinity'"
            | otherwise     -> Opaleye.NumericLit $ realToFrac x
-    , decode = Hasql.float8
+    , decode =
+        Decoder
+          { binary = Hasql.float8
+          , parser = parse (floating A.double)
+          , delimiter = ','
+          }
     , typeName = "float8"
     }
 
@@ -163,7 +222,12 @@ instance DBType Double where
 instance DBType Scientific where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.NumericLit
-    , decode = Hasql.numeric
+    , decode =
+        Decoder
+          { binary = Hasql.numeric
+          , parser = parse A.scientific
+          , delimiter = ','
+          }
     , typeName = "numeric"
     }
 
@@ -174,7 +238,12 @@ instance DBType UTCTime where
     { encode =
         Opaleye.ConstExpr . Opaleye.OtherLit .
         formatTime defaultTimeLocale "'%FT%T%QZ'"
-    , decode = Hasql.timestamptz
+    , decode =
+        Decoder
+          { binary = Hasql.timestamptz
+          , parser = parse Time.utcTime
+          , delimiter = ','
+          }
     , typeName = "timestamptz"
     }
 
@@ -185,7 +254,12 @@ instance DBType Day where
     { encode =
         Opaleye.ConstExpr . Opaleye.OtherLit .
         formatTime defaultTimeLocale "'%F'"
-    , decode = Hasql.date
+    , decode =
+        Decoder
+          { binary = Hasql.date
+          , parser = parse Time.day
+          , delimiter = ','
+          }
     , typeName = "date"
     }
 
@@ -196,7 +270,12 @@ instance DBType LocalTime where
     { encode =
         Opaleye.ConstExpr . Opaleye.OtherLit .
         formatTime defaultTimeLocale "'%FT%T%Q'"
-    , decode = Hasql.timestamp
+    , decode =
+        Decoder
+          { binary = Hasql.timestamp
+          , parser = parse Time.localTime
+          , delimiter = ','
+          }
     , typeName = "timestamp"
     }
 
@@ -207,7 +286,12 @@ instance DBType TimeOfDay where
     { encode =
         Opaleye.ConstExpr . Opaleye.OtherLit .
         formatTime defaultTimeLocale "'%T%Q'"
-    , decode = Hasql.time
+    , decode =
+        Decoder
+          { binary = Hasql.time
+          , parser = parse Time.timeOfDay
+          , delimiter = ','
+          }
     , typeName = "time"
     }
 
@@ -218,7 +302,12 @@ instance DBType CalendarDiffTime where
     { encode =
         Opaleye.ConstExpr . Opaleye.OtherLit .
         formatTime defaultTimeLocale "'%bmon %0Es'"
-    , decode = CalendarDiffTime 0 . realToFrac <$> Hasql.interval
+    , decode =
+        Decoder
+          { binary = CalendarDiffTime 0 . realToFrac <$> Hasql.interval
+          , parser = parse Time.calendarDiffTime
+          , delimiter = ','
+          }
     , typeName = "interval"
     }
 
@@ -227,7 +316,12 @@ instance DBType CalendarDiffTime where
 instance DBType Text where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.StringLit . Text.unpack
-    , decode = Hasql.text
+    , decode =
+        Decoder
+          { binary = Hasql.text
+          , parser = pure . Text.decodeUtf8
+          , delimiter = ','
+          }
     , typeName = "text"
     }
 
@@ -256,7 +350,12 @@ instance DBType (CI Lazy.Text) where
 instance DBType ByteString where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.ByteStringLit
-    , decode = Hasql.bytea
+    , decode =
+        Decoder
+          { binary = Hasql.bytea
+          , parser = parse bytestring
+          , delimiter = ','
+          }
     , typeName = "bytea"
     }
 
@@ -272,7 +371,14 @@ instance DBType Lazy.ByteString where
 instance DBType UUID where
   typeInformation = TypeInformation
     { encode = Opaleye.ConstExpr . Opaleye.StringLit . UUID.toString
-    , decode = Hasql.uuid
+    , decode =
+        Decoder
+          { binary = Hasql.uuid
+          , parser = \input -> case UUID.fromASCIIBytes input of
+              Just a -> pure a
+              Nothing -> Left $ "uuid: bad UUID " <> show input
+          , delimiter = ','
+          }
     , typeName = "uuid"
     }
 
@@ -284,16 +390,30 @@ instance DBType Value where
         Opaleye.ConstExpr . Opaleye.OtherLit .
         Opaleye.quote .
         Lazy.unpack . Lazy.decodeUtf8 . Aeson.encode
-    , decode = Hasql.jsonb
+    , decode =
+        Decoder
+          { binary = Hasql.jsonb
+          , parser = parse Aeson.value
+          , delimiter = ','
+          }
     , typeName = "jsonb"
     }
 
+
 -- | Corresponds to @inet@
-instance DBType (NetAddr IP) where
+instance DBType (IP.NetAddr IP.IP) where
   typeInformation = TypeInformation
     { encode =
-        Opaleye.ConstExpr . Opaleye.StringLit . printNetAddr
-    , decode = Hasql.inet
+        Opaleye.ConstExpr . Opaleye.StringLit . IP.printNetAddr
+    , decode =
+        Decoder
+          { binary = Hasql.inet
+          , parser = parse $
+              textual
+                <|> (`IP.netAddr` 32) . IP.IPv4 <$> textual
+                <|> (`IP.netAddr` 128) . IP.IPv6 <$> textual
+          , delimiter = ','
+          }
     , typeName = "inet"
     }
 
@@ -304,3 +424,7 @@ instance Sql DBType a => DBType [a] where
 
 instance Sql DBType a => DBType (NonEmpty a) where
   typeInformation = nonEmptyTypeInformation nullable typeInformation
+
+
+floating :: Floating a => A.Parser a -> A.Parser a
+floating p = p <|> A.signed (1.0 / 0 <$ "Infinity") <|> 0.0 / 0 <$ "NaN"

--- a/src/Rel8/Type/Decoder.hs
+++ b/src/Rel8/Type/Decoder.hs
@@ -1,0 +1,64 @@
+{-# language DerivingStrategies #-}
+{-# language DeriveFunctor #-}
+{-# language GADTs #-}
+{-# language NamedFieldPuns #-}
+{-# language StandaloneKindSignatures #-}
+
+module Rel8.Type.Decoder (
+  Decoder (..),
+  NullableOrNot (..),
+  Parser,
+  parseDecoder,
+) where
+
+-- base
+import Control.Monad ((>=>))
+import Data.Bifunctor (first)
+import Data.Kind (Type)
+import Prelude
+
+-- bytestring
+import Data.ByteString (ByteString)
+
+-- hasql
+import qualified Hasql.Decoders as Hasql
+
+-- text
+import qualified Data.Text as Text
+
+
+type Parser :: Type -> Type
+type Parser a = ByteString -> Either String a
+
+
+type Decoder :: Type -> Type
+data Decoder a = Decoder
+  { binary :: Hasql.Value a
+    -- ^ How to deserialize from PostgreSQL's binary format.
+  , parser :: Parser a
+    -- ^ How to deserialize from PostgreSQL's text format.
+  , delimiter :: Char
+    -- ^ The delimiter that is used in PostgreSQL's text format in arrays of
+    -- this type (this is almost always ',').
+  }
+  deriving stock (Functor)
+
+
+-- | Apply a parser to 'Decoder'.
+--
+-- This can be used if the data stored in the database should only be subset of
+-- a given 'Decoder'. The parser is applied when deserializing rows
+-- returned.
+parseDecoder :: (a -> Either String b) -> Decoder a -> Decoder b
+parseDecoder f Decoder {binary, parser, delimiter} =
+  Decoder
+    { binary = Hasql.refine (first Text.pack . f) binary
+    , parser = parser >=> f
+    , delimiter
+    }
+
+
+type NullableOrNot :: (Type -> Type) -> Type -> Type
+data NullableOrNot decoder a where
+  NonNullable :: decoder a -> NullableOrNot decoder a
+  Nullable :: decoder a -> NullableOrNot decoder (Maybe a)

--- a/src/Rel8/Type/Information.hs
+++ b/src/Rel8/Type/Information.hs
@@ -11,12 +11,8 @@ module Rel8.Type.Information
 where
 
 -- base
-import Data.Bifunctor ( first )
 import Data.Kind ( Type )
 import Prelude
-
--- hasql
-import qualified Hasql.Decoders as Hasql
 
 -- opaleye
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
@@ -25,7 +21,7 @@ import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
 import Rel8.Type.Name (TypeName)
 
 -- text
-import qualified Data.Text as Text
+import Rel8.Type.Decoder (Decoder, parseDecoder)
 
 
 -- | @TypeInformation@ describes how to encode and decode a Haskell type to and
@@ -35,7 +31,7 @@ type TypeInformation :: Type -> Type
 data TypeInformation a = TypeInformation
   { encode :: a -> Opaleye.PrimExpr
     -- ^ How to encode a single Haskell value as a SQL expression.
-  , decode :: Hasql.Value a
+  , decode :: Decoder a
     -- ^ How to deserialize a single result back to Haskell.
   , typeName :: TypeName
     -- ^ The name of the SQL type.
@@ -66,6 +62,6 @@ parseTypeInformation :: ()
 parseTypeInformation to from TypeInformation {encode, decode, typeName} =
   TypeInformation
     { encode = encode . from
-    , decode = Hasql.refine (first Text.pack . to) decode
+    , decode = parseDecoder to decode
     , typeName
     }

--- a/src/Rel8/Type/JSONBEncoded.hs
+++ b/src/Rel8/Type/JSONBEncoded.hs
@@ -1,11 +1,14 @@
 {-# language OverloadedStrings #-}
 {-# language StandaloneKindSignatures #-}
 
-module Rel8.Type.JSONBEncoded ( JSONBEncoded(..) ) where
+module Rel8.Type.JSONBEncoded
+  ( JSONBEncoded(..)
+  )
+where
 
 -- aeson
-import Data.Aeson ( FromJSON, ToJSON, parseJSON, toJSON )
-import Data.Aeson.Types ( parseEither )
+import Data.Aeson (FromJSON, ToJSON, eitherDecodeStrict, parseJSON, toJSON)
+import Data.Aeson.Types (parseEither)
 
 -- base
 import Data.Bifunctor ( first )
@@ -17,6 +20,7 @@ import qualified Hasql.Decoders as Hasql
 
 -- rel8
 import Rel8.Type ( DBType(..) )
+import Rel8.Type.Decoder (Decoder (..))
 import Rel8.Type.Information ( TypeInformation(..) )
 
 -- text
@@ -31,6 +35,11 @@ newtype JSONBEncoded a = JSONBEncoded { fromJSONBEncoded :: a }
 instance (FromJSON a, ToJSON a) => DBType (JSONBEncoded a) where
   typeInformation = TypeInformation
     { encode = encode typeInformation . toJSON . fromJSONBEncoded
-    , decode = Hasql.refine (first pack . fmap JSONBEncoded . parseEither parseJSON) Hasql.jsonb
+    , decode =
+        Decoder
+          { binary = Hasql.refine (first pack . fmap JSONBEncoded . parseEither parseJSON) Hasql.jsonb
+          , parser = fmap JSONBEncoded . eitherDecodeStrict
+          , delimiter = ','
+          }
     , typeName = "jsonb"
     }

--- a/src/Rel8/Type/Parser.hs
+++ b/src/Rel8/Type/Parser.hs
@@ -1,0 +1,17 @@
+module Rel8.Type.Parser
+  ( parse
+  )
+where
+
+-- attoparsec
+import qualified Data.Attoparsec.ByteString as A
+
+-- base
+import Prelude
+
+-- bytestring
+import Data.ByteString (ByteString)
+
+
+parse :: A.Parser a -> ByteString -> Either String a
+parse parser = A.parseOnly (parser <* A.endOfInput)

--- a/src/Rel8/Type/Parser/ByteString.hs
+++ b/src/Rel8/Type/Parser/ByteString.hs
@@ -1,0 +1,54 @@
+{-# language OverloadedStrings #-}
+{-# language TypeApplications #-}
+
+module Rel8.Type.Parser.ByteString
+  ( bytestring
+  )
+where
+
+-- attoparsec
+import qualified Data.Attoparsec.ByteString.Char8 as A
+
+-- base
+import Control.Applicative ((<|>), many)
+import Control.Monad (guard)
+import Data.Bits ((.|.), shiftL)
+import Data.Char (isOctDigit)
+import Data.Foldable (fold)
+import Prelude
+
+-- base16
+import Data.ByteString.Base16 (decodeBase16Untyped)
+
+-- bytestring
+import Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BS
+
+-- text
+import qualified Data.Text as Text
+
+
+bytestring :: A.Parser ByteString
+bytestring = hex <|> escape
+  where
+    hex = do
+      digits <- "\\x" *> A.takeByteString
+      either (fail . Text.unpack) pure $ decodeBase16Untyped digits
+    escape = fold <$> many (escaped <|> unescaped)
+      where
+        unescaped = A.takeWhile1 (/= '\\')
+        escaped = BS.singleton <$> (backslash <|> octal)
+          where
+            backslash = '\\' <$ "\\\\"
+            octal = do
+              a <- A.char '\\' *> digit
+              b <- digit
+              c <- digit
+              let
+                result = a `shiftL` 6 .|. b `shiftL` 3 .|. c
+              guard $ result < 0o400
+              pure $ toEnum result
+              where
+                digit = do
+                  c <- A.satisfy isOctDigit
+                  pure $ fromEnum c - fromEnum '0'

--- a/src/Rel8/Type/Parser/Time.hs
+++ b/src/Rel8/Type/Parser/Time.hs
@@ -1,0 +1,156 @@
+{-# language OverloadedStrings #-}
+{-# language TypeApplications #-}
+
+module Rel8.Type.Parser.Time
+  ( calendarDiffTime
+  , day
+  , localTime
+  , timeOfDay
+  , utcTime
+  )
+where
+
+-- attoparsec
+import qualified Data.Attoparsec.ByteString.Char8 as A
+
+-- base
+import Control.Applicative ((<|>), optional)
+import Data.Bits ((.&.))
+import Data.Bool (bool)
+import Data.Fixed (Fixed (MkFixed), Pico, divMod')
+import Data.Functor (void)
+import Data.Int (Int64)
+import Prelude
+
+-- bytestring
+import qualified Data.ByteString as BS
+
+-- time
+import Data.Time.Calendar (Day, addDays, fromGregorianValid)
+import Data.Time.Clock (DiffTime, UTCTime (UTCTime))
+import Data.Time.Format.ISO8601 (iso8601ParseM)
+import Data.Time.LocalTime
+  ( CalendarDiffTime (CalendarDiffTime)
+  , LocalTime (LocalTime)
+  , TimeOfDay (TimeOfDay)
+  , sinceMidnight
+  )
+
+-- utf8
+import qualified Data.ByteString.UTF8 as UTF8
+
+
+day :: A.Parser Day
+day = do
+  y <- A.decimal <* A.char '-'
+  m <- twoDigits <* A.char '-'
+  d <- twoDigits
+  maybe (fail "Day: invalid date") pure $ fromGregorianValid y m d
+
+
+timeOfDay :: A.Parser TimeOfDay
+timeOfDay = do
+  h <- twoDigits
+  m <- A.char ':' *> twoDigits
+  s <- A.char ':' *> secondsParser
+  if h < 24 && m < 60 && s <= 60
+    then pure $ TimeOfDay h m s
+    else fail "TimeOfDay: invalid time"
+
+
+localTime :: A.Parser LocalTime
+localTime = LocalTime <$> day <* separator <*> timeOfDay
+  where
+    separator = A.char ' ' <|> A.char 'T'
+
+
+utcTime :: A.Parser UTCTime
+utcTime = do
+  LocalTime date time <- localTime
+  tz <- timeZone
+  let
+    (days, time') = (sinceMidnight time + tz) `divMod'` oneDay
+      where
+        oneDay = 24 * 60 * 60
+    date' = addDays days date
+  pure $ UTCTime date' time'
+
+
+calendarDiffTime :: A.Parser CalendarDiffTime
+calendarDiffTime = iso8601 <|> postgres
+  where
+    iso8601 = A.takeByteString >>= iso8601ParseM . UTF8.toString
+    at = optional (A.char '@') *> A.skipSpace
+    plural unit = A.skipSpace <* (unit <* optional "s") <* A.skipSpace
+    parseMonths = sql <|> postgresql
+      where
+        sql = A.signed $ do
+          years <- A.decimal <* A.char '-'
+          months <- A.decimal <* A.skipSpace
+          pure $ years * 12 + months
+        postgresql = do
+          at
+          years <- A.signed A.decimal <* plural "year" <|> pure 0
+          months <- A.signed A.decimal <* plural "mon" <|> pure 0
+          pure $ years * 12 + months
+    parseTime = (+) <$> parseDays <*> time
+      where
+        time = realToFrac <$> (sql <|> postgresql)
+          where
+            sql = A.signed $ do
+              h <- A.signed A.decimal <* A.char ':'
+              m <- twoDigits <* A.char ':'
+              s <- secondsParser
+              pure $ fromIntegral (((h * 60) + m) * 60) + s
+            postgresql = do
+              h <- A.signed A.decimal <* plural "hour" <|> pure 0
+              m <- A.signed A.decimal <* plural "min" <|> pure 0
+              s <- secondsParser <* plural "sec" <|> pure 0
+              pure $ fromIntegral @Int (((h * 60) + m) * 60) + s
+        parseDays = do
+          days <- A.signed A.decimal <* (plural "days" <|> skipSpace1) <|> pure 0
+          pure $ fromIntegral @Int days * 24 * 60 * 60
+    postgres = do
+      months <- parseMonths
+      time <- parseTime
+      ago <- (True <$ (A.skipSpace *> "ago")) <|> pure False
+      pure $ CalendarDiffTime (bool id negate ago months) (bool id negate ago time)
+
+
+secondsParser :: A.Parser Pico
+secondsParser = do
+  integral <- twoDigits
+  mfractional <- optional (A.char '.' *> A.takeWhile1 A.isDigit)
+  pure $ case mfractional of
+    Nothing -> fromIntegral integral
+    Just fractional -> parseFraction (fromIntegral integral) fractional
+ where
+  parseFraction integral digits = MkFixed (fromIntegral (n * 10 ^ e))
+    where
+      e = max 0 (12 - BS.length digits)
+      n = BS.foldl' go (integral :: Int64) (BS.take 12 digits)
+        where
+          go acc digit = 10 * acc + fromIntegral (fromEnum digit .&. 0xf)
+
+
+twoDigits :: A.Parser Int
+twoDigits = do
+  u <- A.digit
+  l <- A.digit
+  pure $ fromEnum u .&. 0xf * 10 + fromEnum l .&. 0xf
+
+
+timeZone :: A.Parser DiffTime
+timeZone = 0 <$ A.char 'Z' <|> diffTime
+
+
+diffTime :: A.Parser DiffTime
+diffTime = A.signed $ do
+  h <- twoDigits
+  m <- A.char ':' *> twoDigits <|> pure 0
+  s <- A.char ':' *> secondsParser <|> pure 0
+  pure $ sinceMidnight $ TimeOfDay h m s
+
+
+skipSpace1 :: A.Parser ()
+skipSpace1 = void $ A.takeWhile1 A.isSpace

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -485,14 +485,12 @@ testDBType getTestDatabase = testGroup "DBType instances"
             xs <- Rel8.catListTable (Rel8.listTable [Rel8.listTable [Rel8.litExpr x, Rel8.litExpr y]])
             Rel8.catListTable xs
         diff res'' (==) [x, y]
-{-
         res''' <- lift do
           statement () $ Rel8.run $ Rel8.select do
             xss <- Rel8.catListTable (Rel8.listTable [Rel8.listTable [Rel8.listTable [Rel8.litExpr x, Rel8.litExpr y]]])
             xs <- Rel8.catListTable xss
             Rel8.catListTable xs
         diff res''' (==) [x, y]
--}
 
     genComposite :: Gen Composite
     genComposite = do


### PR DESCRIPTION
This is a possible fix to #168. With this we can `catListTable` arbitrarily deep trees of `ListTable`s.

It comes at a relatively high cost, however.

Currently we represent nested arrays with anonymous records. This works reasonably well, except that we can't extract the field from the anonymous record when we need it (PostgreSQL [theoretically](https://www.postgresql.org/docs/13/release-13.html#id-1.11.6.16.5.6) suports `.f1` syntax since PG13 but it only works in very limited situations). But it does mean we can decode the results using Hasql's binary decoders, and ordering works how we expect to (`array[row(array[9])] < array[row(array[10])]`).

What this PR does is instead represent nested arrays as text. To be able to decode this, we need each `DBType` to supply a text parser in addition to a binary decoder. It also means that ordering is no longer intuitive, because `array[array[9]::text] > array[array[10]::text]`. However, it does mean we can nest `catListTable`s to our heart's content and it will always just work.