### PR TITLE
Statements overhaul (support for statement-level `WITH`)

### DIFF
--- a/rel8.cabal
+++ b/rel8.cabal
@@ -28,7 +28,7 @@ library
     , contravariant
     , hasql ^>= 1.6.1.2
     , network-ip
-    , opaleye ^>= 0.9.6.1
+    , opaleye ^>= 0.9.7.0
     , pretty
     , profunctors
     , product-profunctors
@@ -38,7 +38,9 @@ library
     , text
     , these
     , time
+    , transformers
     , uuid
+    , vector
   default-language:
     Haskell2010
   ghc-options:
@@ -155,6 +157,7 @@ library
     Rel8.Statement.Insert
     Rel8.Statement.OnConflict
     Rel8.Statement.Returning
+    Rel8.Statement.Rows
     Rel8.Statement.Select
     Rel8.Statement.Set
     Rel8.Statement.SQL
@@ -162,6 +165,7 @@ library
     Rel8.Statement.Using
     Rel8.Statement.View
     Rel8.Statement.Where
+    Rel8.Statement.With
 
     Rel8.Table
     Rel8.Table.ADT

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -335,17 +335,20 @@ module Rel8
   , OnConflict(..)
   , Upsert(..)
   , insert
+  , insert_
   , unsafeDefault
   , showInsert
 
     -- ** @DELETE@
   , Delete(..)
   , delete
+  , delete_
   , showDelete
 
     -- ** @UPDATE@
   , Update(..)
   , update
+  , update_
   , showUpdate
 
     -- ** @.. RETURNING@
@@ -354,6 +357,12 @@ module Rel8
     -- ** @CREATE VIEW@
   , createView
   , createOrReplaceView
+
+    -- ** @WITH@
+  , runWith
+  , withQuery
+  , withInsert
+  , showWith
 
     -- ** Sequences
   , nextval
@@ -429,6 +438,7 @@ import Rel8.Statement.Select
 import Rel8.Statement.SQL
 import Rel8.Statement.Update
 import Rel8.Statement.View
+import Rel8.Statement.With
 import Rel8.Table
 import Rel8.Table.ADT
 import Rel8.Table.Aggregate

--- a/src/Rel8/Query/SQL.hs
+++ b/src/Rel8/Query/SQL.hs
@@ -9,13 +9,19 @@ where
 -- base
 import Prelude
 
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
+
 -- rel8
 import Rel8.Expr ( Expr )
 import Rel8.Query ( Query )
 import Rel8.Statement.Select ( ppSelect )
 import Rel8.Table ( Table )
 
+-- transformers
+import Control.Monad.Trans.State.Strict (evalState)
+
 
 -- | Convert a 'Query' to a 'String' containing a @SELECT@ statement.
 showQuery :: Table Expr a => Query a -> String
-showQuery = show . ppSelect
+showQuery = show . (`evalState` Opaleye.start) . ppSelect

--- a/src/Rel8/Statement.hs
+++ b/src/Rel8/Statement.hs
@@ -1,0 +1,213 @@
+{-# language DataKinds #-}
+{-# language FlexibleContexts #-}
+{-# language FlexibleInstances #-}
+{-# language FunctionalDependencies #-}
+{-# language GADTs #-}
+{-# language LambdaCase #-}
+{-# language NamedFieldPuns #-}
+{-# language RankNTypes #-}
+{-# language RecordWildCards #-}
+{-# language ScopedTypeVariables #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TupleSections #-}
+{-# language TypeApplications #-}
+{-# language TypeOperators #-}
+{-# language ViewPatterns #-}
+
+module Rel8.Statement
+  ( Statement (..)
+  , IsStatement
+  , run
+  , toStatement
+  , showStatement
+  )
+where
+
+-- base
+import Data.Kind (Type, Constraint)
+import Prelude
+
+-- hasql
+import qualified Hasql.Decoders as Hasql
+import qualified Hasql.Encoders as Hasql
+import qualified Hasql.Statement as Hasql
+
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
+
+-- pretty
+import Text.PrettyPrint (Doc)
+
+-- rel8
+import Rel8.Expr (Expr)
+import Rel8.Query (Query)
+import Rel8.Statement.Delete (Delete, decodeDelete, ppDelete, withDelete)
+import Rel8.Statement.Insert (Insert, decodeInsert, ppInsert, withInsert)
+import Rel8.Statement.Rows (Rows (..))
+import Rel8.Statement.Select (decodeSelect, ppSelect)
+import Rel8.Statement.Update (Update, decodeUpdate, ppUpdate, withUpdate)
+import Rel8.Statement.With (With, applyWith, justWith, ppAlias, ppWith)
+import Rel8.Table (Table)
+
+-- text
+import qualified Data.Text as Text
+import Data.Text.Encoding (encodeUtf8)
+
+-- transformers
+import Control.Monad.Trans.State.Strict (State, evalState)
+
+
+-- | In addition to @SELECT@, @INSERT@, @UPDATE@ and @DELETE@, PostgreSQL
+-- also supports compositions thereof via its statement-level @WITH@ syntax
+-- (with some caveats). Each such \"sub-statement\" can reference the results
+-- of previous sub-statements. This pseudo-monadic interface is encapsulated
+-- by the 'Rel8.Statement.Do.>>=' from "Rel8.Statement.Do", which can be
+-- invoked using the @QualifiedDo@ language extension.
+--
+-- The caveat with this is that the [side-effects of these sub-statements
+-- are not visible to other sub-statements](https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-MODIFYING),
+-- only the results of a @SELECT@ or @RETURNING@ clause. So an @INSERT@ into
+-- a table followed immediately by a select therefrom will not include the
+-- inserted rows; however, it is possible to return the inserted rows using
+-- @RETURNING@, and to 'Rel8.unionAll' this with the result of a @SELECT@
+-- from the same table, which will produce the desired result.
+--
+-- An example of where this can be useful is if you want to delete rows from
+-- a table and to immediately log their deletion in a log table.
+--
+-- @
+-- import qualified Rel8.Statement.Do as Statement
+--
+-- deleteFoo :: (Foo Expr -> Expr Bool) -> Statement 'Nothing
+-- deleteFoo predicate = Statement.do
+--   foos <-
+--     Delete
+--       { from = fooSchema
+--       , using = pure ()
+--       , deleteWhere = \_ -> predicate
+--       , returning = Returning id
+--       }
+--   Insert
+--     { into = deletedFooSchema
+--     , rows = do
+--         Foo {..} <- foos
+--         let
+--           deletedAt = 'Rel8.Expr.Time.now'
+--         pure DeletedFoo {..}
+--     , onConflict = Abort
+--     , returning = NoReturning
+--     }
+-- @
+type Statement :: Maybe Type -> Type
+data Statement returning where
+  Select :: Table Expr a => Query a -> Statement ('Just a)
+  Insert :: Insert a -> Statement a
+  Update :: Update a -> Statement a
+  Delete :: Delete a -> Statement a
+  Bind :: Statement ('Just a) -> (Query a -> Statement b) -> Statement b
+  Then :: Statement a -> Statement b -> Statement b
+
+
+ppDecodeStatement :: Statement exprs -> (Doc, Rows exprs a -> Hasql.Result a)
+ppDecodeStatement = \statement -> (`evalState` Opaleye.start) $ do
+  (dlist, _, _, doc, decoder) <- go id statement
+  let
+    withs = dlist []
+    doc' = ppWith withs doc 
+  pure (doc', decoder)
+  where
+    go :: ()
+      => ([(Doc, Doc)] -> [(Doc, Doc)])
+      -> Statement exprs
+      -> State Opaleye.Tag
+           ( [(Doc, Doc)] -> [(Doc, Doc)]
+           , [(Doc, Doc)] -> [(Doc, Doc)]
+           , With exprs
+           , Doc
+           , Rows exprs a -> Hasql.Result a
+           )
+    go dlist = \case
+      Select @exprs query -> do
+        doc <- ppSelect query
+        with <- justWith @exprs
+        let
+          dlist' = dlist . ((ppAlias with, doc) :)
+          decode rows = decodeSelect rows
+        pure (dlist, dlist', with, doc, decode)
+      Insert insert -> do
+        doc <- ppInsert insert
+        with <- withInsert insert
+        let
+          dlist' = dlist . ((ppAlias with, doc) :)
+          decode rows = decodeInsert rows insert
+        pure (dlist, dlist', with, doc, decode)
+      Update update -> do
+        doc <- ppUpdate update
+        with <- withUpdate update
+        let
+          dlist' = dlist . ((ppAlias with, doc) :)
+          decode rows = decodeUpdate rows update
+        pure (dlist, dlist', with, doc, decode)
+      Delete delete -> do
+        doc <- ppDelete delete
+        with <- withDelete delete
+        let
+          dlist' = dlist . ((ppAlias with, doc) :)
+          decode rows = decodeDelete rows delete
+        pure (dlist, dlist', with, doc, decode)
+      Bind prev f -> do
+        (_, dlist', with, _, _) <- go dlist prev
+        let
+          next = applyWith with f
+        go dlist' next
+      Then prev next -> do
+        (_, dlist', _, _, _) <- go dlist prev
+        go dlist' next
+
+
+-- | 'IsStatement' allows 'run' to be polymorphic in the types of statements
+-- it accepts. It can be either 'Query', 'Insert', 'Update', 'Delete' or
+-- 'Statement'.
+type IsStatement :: Maybe Type -> Type -> Constraint
+class IsStatement returning statement | statement -> returning where
+  toStatement :: statement -> Statement returning
+
+
+instance (f ~ Query, Table Expr a) => IsStatement ('Just a) (f a) where
+  toStatement = Select
+
+
+instance IsStatement a (Insert a) where
+  toStatement = Insert
+
+
+instance IsStatement a (Update a) where
+  toStatement = Update
+
+
+instance IsStatement a (Delete a) where
+  toStatement = Delete
+
+
+instance IsStatement a (Statement a) where
+  toStatement = id
+
+
+-- | Convert an 'IsStatement' (e.g., a 'Query' or an 'Insert') to a runnable
+-- 'Hasql.Statement' returning rows according to the given 'Rows' parameter.
+run :: IsStatement exprs statement
+  => Rows exprs a -> statement -> Hasql.Statement () a
+run rows statement =
+  Hasql.Statement bytes params (decode rows) prepare
+  where
+    bytes = encodeUtf8 $ Text.pack sql
+    params = Hasql.noParams
+    prepare = False
+    sql = show doc
+    (doc, decode) = ppDecodeStatement (toStatement statement)
+
+
+-- | Convert a 'Statement' to a 'String' containing a @SELECT@, @INSERT@,
+-- @UPDATE@, @DELETE@ or @WITH@ statement.
+showStatement :: Statement a -> String
+showStatement = show . fst . ppDecodeStatement

--- a/src/Rel8/Statement/Delete.hs
+++ b/src/Rel8/Statement/Delete.hs
@@ -1,25 +1,33 @@
 {-# language DuplicateRecordFields #-}
+{-# language FlexibleContexts #-}
 {-# language GADTs #-}
 {-# language NamedFieldPuns #-}
-{-# language RankNTypes #-}
 {-# language RecordWildCards #-}
+{-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
 {-# language StrictData #-}
+{-# language TypeApplications #-}
 
 module Rel8.Statement.Delete
   ( Delete(..)
   , delete
+  , delete_
   , ppDelete
   )
 where
 
 -- base
 import Data.Kind ( Type )
+import Data.Int (Int64)
 import Prelude
 
 -- hasql
+import qualified Hasql.Decoders as Hasql
 import qualified Hasql.Encoders as Hasql
 import qualified Hasql.Statement as Hasql
+
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
 
 -- pretty
 import Text.PrettyPrint ( Doc, (<+>), ($$), text )
@@ -29,13 +37,20 @@ import Rel8.Expr ( Expr )
 import Rel8.Query ( Query )
 import Rel8.Schema.Name ( Selects )
 import Rel8.Schema.Table ( TableSchema, ppTable )
-import Rel8.Statement.Returning ( Returning, decodeReturning, ppReturning )
+import Rel8.Statement.Returning
+  ( Returning(Returning)
+  , ppReturning
+  )
 import Rel8.Statement.Using ( ppUsing )
 import Rel8.Statement.Where ( ppWhere )
+import Rel8.Table.Serialize (Serializable, parse)
 
 -- text
-import qualified Data.Text as Text
+import qualified Data.Text as Text ( pack )
 import Data.Text.Encoding ( encodeUtf8 )
+
+-- transformers
+import Control.Monad.Trans.State.Strict (State, evalState)
 
 
 -- | The constituent parts of a @DELETE@ statement.
@@ -55,25 +70,40 @@ data Delete a where
     -> Delete a
 
 
-ppDelete :: Delete a -> Doc
-ppDelete Delete {..} = case ppUsing using of
-  Nothing ->
-    text "DELETE FROM" <+> ppTable from $$
-    text "WHERE false"
-  Just (usingDoc, i) ->
-    text "DELETE FROM" <+> ppTable from $$
-    usingDoc $$
-    ppWhere from (deleteWhere i) $$
-    ppReturning from returning
+ppDelete :: Delete a -> State Opaleye.Tag Doc
+ppDelete Delete {..} = do
+  musing <- ppUsing using
+  pure $ case musing of
+    Nothing ->
+      text "DELETE FROM" <+> ppTable from $$
+      text "WHERE false"
+    Just (usingDoc, i) ->
+      text "DELETE FROM" <+> ppTable from $$
+      usingDoc $$
+      ppWhere from (deleteWhere i) $$
+      ppReturning from returning
 
 
--- | Run a 'Delete' statement.
-delete :: Delete a -> Hasql.Statement () a
+-- | Run a @DELETE .. RETURNING@ statement.
+delete :: Serializable expr a => Delete (Query expr) -> Hasql.Statement () [a]
 delete d@Delete {returning} = Hasql.Statement bytes params decode prepare
   where
     bytes = encodeUtf8 $ Text.pack sql
     params = Hasql.noParams
-    decode = decodeReturning returning
+    decode = case returning of
+      Returning (_ :: exprs -> returning) -> Hasql.rowList (parse @returning)
     prepare = False
     sql = show doc
-    doc = ppDelete d
+    doc = evalState (ppDelete d) Opaleye.start
+
+
+-- | Run a @DELETE@ statement and return the number of rows affected.
+delete_ :: Delete a -> Hasql.Statement () Int64
+delete_ d = Hasql.Statement bytes params decode prepare
+  where
+    bytes = encodeUtf8 $ Text.pack sql
+    params = Hasql.noParams
+    decode = Hasql.rowsAffected
+    prepare = False
+    sql = show doc
+    doc = evalState (ppDelete d) Opaleye.start

--- a/src/Rel8/Statement/Do.hs
+++ b/src/Rel8/Statement/Do.hs
@@ -1,0 +1,80 @@
+{-# language DataKinds #-}
+{-# language FlexibleContexts #-}
+
+{-|
+
+This module is intended to be imported qualified as follows:
+
+@
+import qualified Rel8.Statement.Do as Statement
+@
+
+It's intended to be used wth the @QualifiedDo@ language extension.
+
+-}
+
+module Rel8.Statement.Do
+  ( (>>=)    
+  , (>>)
+  , pure
+  , return
+  , fmap
+  , liftA2
+  )
+where
+
+-- base
+import Data.Function ((.))
+import Data.Maybe (Maybe (Just))
+import Prelude ()
+
+-- rel8
+import Rel8.Expr (Expr)
+import Rel8.Query (Query)
+import Rel8.Statement
+  ( Statement (Select, Bind, Then)
+  , IsStatement
+  , toStatement
+  )
+import Rel8.Table (Table)
+
+
+-- | See 'Statement'. For use with the @QualifiedDo@ extension.
+(>>=) :: (IsStatement ('Just a) statement, IsStatement b statement')
+  => statement -> (Query a -> statement') -> Statement b
+a >>= f = Bind (toStatement a) (toStatement . f)
+infixl 1 >>=
+
+
+-- | See 'Statement'. For use with the @QualifiedDo@ extension.
+(>>) :: (IsStatement a statement, IsStatement b statement')
+  => statement -> statement' -> Statement b
+a >> b = Then (toStatement a) (toStatement b)
+infixl 1 >>
+
+
+-- | See 'Statement'. For use with the @QualifiedDo@ extension.
+pure :: Table Expr a => Query a -> Statement ('Just a)
+pure = Select
+
+
+-- | See 'Statement'. For use with the @QualifiedDo@ extension.
+return :: Table Expr a => Query a -> Statement ('Just a)
+return = Select
+
+
+-- | See 'Statement'. For use with the @QualifiedDo@ extension.
+fmap :: (IsStatement ('Just a) statement, Table Expr b)
+  => (Query a -> Query b)
+  -> statement
+  -> Statement ('Just b)
+fmap f m = m >>= pure . f
+
+
+-- | See 'Statement'. For use with the @QualifiedDo@ extension.
+liftA2 :: (IsStatement ('Just a) statement, IsStatement ('Just b) statement', Table Expr c)
+  => (Query a -> Query b -> Query c)
+  -> statement
+  -> statement'
+  -> Statement ('Just c)
+liftA2 f as bs = as >>= \a -> bs >>= \b -> pure (f a b)

--- a/src/Rel8/Statement/Returning.hs
+++ b/src/Rel8/Statement/Returning.hs
@@ -1,3 +1,5 @@
+{-# language DataKinds #-}
+{-# language FlexibleContexts #-}
 {-# language GADTs #-}
 {-# language LambdaCase #-}
 {-# language NamedFieldPuns #-}
@@ -8,22 +10,16 @@
 {-# language TypeApplications #-}
 
 module Rel8.Statement.Returning
-  ( Returning( NumberOfRowsAffected, Projection )
-  , decodeReturning
+  ( Returning( NoReturning, Returning )
   , ppReturning
   )
 where
 
 -- base
-import Control.Applicative ( liftA2 )
 import Data.Foldable ( toList )
-import Data.Int ( Int64 )
 import Data.Kind ( Type )
 import Data.List.NonEmpty ( NonEmpty )
 import Prelude
-
--- hasql
-import qualified Hasql.Decoders as Hasql
 
 -- opaleye
 import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
@@ -34,94 +30,33 @@ import qualified Opaleye.Internal.Sql as Opaleye
 import Text.PrettyPrint ( Doc, (<+>), text )
 
 -- rel8
+import Rel8.Expr (Expr)
+import Rel8.Query ( Query )
 import Rel8.Schema.Name ( Selects )
 import Rel8.Schema.Table ( TableSchema(..) )
+import Rel8.Table (Table)
 import Rel8.Table.Opaleye ( castTable, exprs, view )
-import Rel8.Table.Serialize ( Serializable, parse )
-
--- semigropuoids
-import Data.Functor.Apply ( Apply, (<.>) )
 
 
--- | 'Rel8.Insert', 'Rel8.Update' and 'Rel8.Delete' all support returning either
--- the number of rows affected, or the actual rows modified.
+-- | 'Rel8.Insert', 'Rel8.Update' and 'Rel8.Delete' all support an optional
+-- @RETURNING@ clause.
 type Returning :: Type -> Type -> Type
 data Returning names a where
-  Pure :: a -> Returning names a
-  Ap :: Returning names (a -> b) -> Returning names a -> Returning names b
+  -- | No @RETURNING@ clause
+  NoReturning :: Returning names ()
 
-  -- | Return the number of rows affected.
-  NumberOfRowsAffected :: Returning names Int64
-
-  -- | 'Projection' allows you to project out of the affected rows, which can
+  -- | 'Returning' allows you to project out of the affected rows, which can
   -- be useful if you want to log exactly which rows were deleted, or to view
   -- a generated id (for example, if using a column with an autoincrementing
   -- counter via 'Rel8.nextval').
-  Projection :: (Selects names exprs, Serializable returning a)
-    => (exprs -> returning)
-    -> Returning names [a]
-
-
-instance Functor (Returning names) where
-  fmap f = \case
-    Pure a -> Pure (f a)
-    Ap g a -> Ap (fmap (f .) g) a
-    m -> Ap (Pure f) m
-
-
-instance Apply (Returning names) where
-  (<.>) = Ap
-
-
-instance Applicative (Returning names) where
-  pure = Pure
-  (<*>) = Ap
+  Returning :: (Selects names exprs, Table Expr a) => (exprs -> a) -> Returning names (Query a)
 
 
 projections :: ()
   => TableSchema names -> Returning names a -> Maybe (NonEmpty Opaleye.PrimExpr)
-projections schema@TableSchema {columns} = \case
-  Pure _ -> Nothing
-  Ap f a -> projections schema f <> projections schema a
-  NumberOfRowsAffected -> Nothing
-  Projection f -> Just (exprs (castTable (f (view columns))))
-
-
-runReturning :: ()
-  => ((Int64 -> a) -> r)
-  -> (forall x. Hasql.Row x -> ([x] -> a) -> r)
-  -> Returning names a
-  -> r
-runReturning rowCount rowList = \case
-  Pure a -> rowCount (const a)
-  Ap fs as ->
-    runReturning
-      (\withCount ->
-         runReturning
-           (\withCount' -> rowCount (withCount <*> withCount'))
-           (\decoder -> rowList decoder . liftA2 withCount length64)
-           as)
-      (\decoder withRows ->
-         runReturning
-           (\withCount -> rowList decoder $ withRows <*> withCount . length64)
-           (\decoder' withRows' ->
-             rowList (liftA2 (,) decoder decoder') $
-               withRows <$> fmap fst <*> withRows' . fmap snd)
-           as)
-      fs
-  NumberOfRowsAffected -> rowCount id
-  Projection (_ :: exprs -> returning) -> rowList decoder' id
-    where
-      decoder' = parse @returning
-  where
-    length64 :: Foldable f => f x -> Int64
-    length64 = fromIntegral . length
-
-
-decodeReturning :: Returning names a -> Hasql.Result a
-decodeReturning = runReturning
-  (<$> Hasql.rowsAffected)
-  (\decoder withRows -> withRows <$> Hasql.rowList decoder)
+projections TableSchema {columns} = \case
+  NoReturning -> Nothing
+  Returning f -> Just (exprs (castTable (f (view columns))))
 
 
 ppReturning :: TableSchema names -> Returning names a -> Doc

--- a/src/Rel8/Statement/Rows.hs
+++ b/src/Rel8/Statement/Rows.hs
@@ -1,0 +1,53 @@
+{-# language DataKinds #-}
+{-# language GADTs #-}
+{-# language StandaloneKindSignatures #-}
+
+module Rel8.Statement.Rows
+  ( Rows (..)    
+  )
+where
+
+-- base
+import Data.Int (Int64)
+import Data.Kind (Type)
+import Prelude
+
+-- rel8
+import Rel8.Table.Serialize (Serializable)
+
+-- vector
+import Data.Vector (Vector)
+
+
+-- | To 'Rel8.run' a statement, a 'Rows' parameter is required. 'Rows'
+-- specifies how the rows (if any) returned by the given statement should be
+-- processed in Haskell.
+type Rows :: Maybe Type -> Type -> Type
+data Rows returning result where
+  Void :: Rows returning ()
+  -- ^ 'Void' means you don't care about the rows returned by the statement.
+  -- A statement 'Rel8.run' with 'Void' will always return @()@ whether the
+  -- statement itself produces any rows or not.
+  RowsAffected :: Rows 'Nothing Int64
+  -- ^ 'RowsAffected' returns the number of rows that were affected by an
+  -- @INSERT@, @UPDATE@ or @DELETE@ statement. The statement must not be a
+  -- 'Rel8.Query' and must have a @returning@ field set to
+  -- 'Rel8.NoReturning'.
+  Single :: Serializable exprs a => Rows ('Just exprs) a
+  -- ^ 'Single' decodes a single row of @exprs@ as an @a@. If the
+  -- corresponding statement returns a number of rows other than 1, then a
+  -- runtime exception is thrown. The statement must be either a 'Rel8.Query'
+  -- or have a @returning@ field set to 'Rel8.Returning'.
+  Maybe :: Serializable exprs a => Rows ('Just exprs) (Maybe a)
+  -- ^ 'Maybe' decodes zero or one rows of @exprs@ into a @Maybe a@. If the
+  -- corresponding statement returns a number of rows other than 0 or 1, then
+  -- a runtime exception is thrown. The statement must be either a 'Rel8.Query'
+  -- or have a @returning@ field set to 'Rel8.Returning'. 
+  List :: Serializable exprs a => Rows ('Just exprs) [a]
+  -- ^ 'List' decodes any number of rows of @exprs@ into a @[a]@. The
+  -- statement must be either a 'Rel8.Query' or have a @returning@ field set
+  -- to 'Rel8.Returning'.
+  Vector :: Serializable exprs a => Rows ('Just exprs) (Vector a)
+  -- ^ 'List' decodes any number of rows of @exprs@ into a @Vector a@. The
+  -- statement must be either a 'Rel8.Query' or have a @returning@ field set
+  -- to 'Rel8.Returning'.

--- a/src/Rel8/Statement/SQL.hs
+++ b/src/Rel8/Statement/SQL.hs
@@ -8,22 +8,28 @@ where
 -- base
 import Prelude
 
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
+
 -- rel8
 import Rel8.Statement.Delete ( Delete, ppDelete )
 import Rel8.Statement.Insert ( Insert, ppInsert )
 import Rel8.Statement.Update ( Update, ppUpdate )
 
+-- transformers
+import Control.Monad.Trans.State.Strict (evalState)
+
 
 -- | Convert a 'Delete' to a 'String' containing a @DELETE@ statement.
 showDelete :: Delete a -> String
-showDelete = show . ppDelete
+showDelete = show . (`evalState` Opaleye.start) . ppDelete
 
 
 -- | Convert an 'Insert' to a 'String' containing an @INSERT@ statement.
 showInsert :: Insert a -> String
-showInsert = show . ppInsert
+showInsert = show . (`evalState` Opaleye.start) . ppInsert
 
 
 -- | Convert an 'Update' to a 'String' containing an @UPDATE@ statement.
 showUpdate :: Update a -> String
-showUpdate = show . ppUpdate
+showUpdate = show . (`evalState` Opaleye.start) . ppUpdate

--- a/src/Rel8/Statement/Update.hs
+++ b/src/Rel8/Statement/Update.hs
@@ -1,24 +1,33 @@
 {-# language DuplicateRecordFields #-}
+{-# language FlexibleContexts #-}
 {-# language GADTs #-}
 {-# language NamedFieldPuns #-}
 {-# language RecordWildCards #-}
+{-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
 {-# language StrictData #-}
+{-# language TypeApplications #-}
 
 module Rel8.Statement.Update
   ( Update(..)
   , update
+  , update_
   , ppUpdate
   )
 where
 
 -- base
 import Data.Kind ( Type )
+import Data.Int ( Int64 )
 import Prelude
 
 -- hasql
+import qualified Hasql.Decoders as Hasql
 import qualified Hasql.Encoders as Hasql
 import qualified Hasql.Statement as Hasql
+
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
 
 -- pretty
 import Text.PrettyPrint ( Doc, (<+>), ($$), text )
@@ -28,14 +37,21 @@ import Rel8.Expr ( Expr )
 import Rel8.Query ( Query )
 import Rel8.Schema.Name ( Selects )
 import Rel8.Schema.Table ( TableSchema(..), ppTable )
-import Rel8.Statement.Returning ( Returning, decodeReturning, ppReturning )
+import Rel8.Statement.Returning
+  ( Returning(Returning)
+  , ppReturning
+  )
 import Rel8.Statement.Set ( ppSet )
 import Rel8.Statement.Using ( ppFrom )
 import Rel8.Statement.Where ( ppWhere )
+import Rel8.Table.Serialize (Serializable, parse)
 
 -- text
-import qualified Data.Text as Text
+import qualified Data.Text as Text ( pack )
 import Data.Text.Encoding ( encodeUtf8 )
+
+-- transformers
+import Control.Monad.Trans.State.Strict (State, evalState)
 
 
 -- | The constituent parts of an @UPDATE@ statement.
@@ -57,27 +73,42 @@ data Update a where
     -> Update a
 
 
-ppUpdate :: Update a -> Doc
-ppUpdate Update {..} = case ppFrom from of
-  Nothing ->
-    text "UPDATE" <+> ppTable target $$
-    ppSet target id $$
-    text "WHERE false"
-  Just (fromDoc, i) ->
-    text "UPDATE" <+> ppTable target $$
-    ppSet target (set i) $$
-    fromDoc $$
-    ppWhere target (updateWhere i) $$
-    ppReturning target returning
+ppUpdate :: Update a -> State Opaleye.Tag Doc
+ppUpdate Update {..} = do
+  mfrom <- ppFrom from
+  pure $ case mfrom of
+    Nothing -> 
+      text "UPDATE" <+> ppTable target $$
+      ppSet target id $$
+      text "WHERE false"
+    Just (fromDoc, i) ->
+      text "UPDATE" <+> ppTable target $$
+      ppSet target (set i) $$
+      fromDoc $$
+      ppWhere target (updateWhere i) $$
+      ppReturning target returning
 
 
--- | Run an @UPDATE@ statement.
-update :: Update a -> Hasql.Statement () a
+-- | Run an @UPDATE .. RETURNING@ statement.
+update :: Serializable exprs a => Update (Query exprs) -> Hasql.Statement () [a]
 update u@Update {returning} = Hasql.Statement bytes params decode prepare
   where
     bytes = encodeUtf8 $ Text.pack sql
     params = Hasql.noParams
-    decode = decodeReturning returning
+    decode = case returning of
+      Returning (_ :: exprs -> returning) -> Hasql.rowList (parse @returning)
     prepare = False
     sql = show doc
-    doc = ppUpdate u
+    doc = evalState (ppUpdate u) Opaleye.start
+
+
+-- | Run an @UPDATE@ statement and return the number of rows affected.
+update_ :: Update a -> Hasql.Statement () Int64
+update_ u = Hasql.Statement bytes params decode prepare
+  where
+    bytes = encodeUtf8 $ Text.pack sql
+    params = Hasql.noParams
+    decode = Hasql.rowsAffected
+    prepare = False
+    sql = show doc
+    doc = evalState (ppUpdate u) Opaleye.start

--- a/src/Rel8/Statement/Using.hs
+++ b/src/Rel8/Statement/Using.hs
@@ -7,6 +7,9 @@ where
 -- base
 import Prelude
 
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
+
 -- pretty
 import Text.PrettyPrint ( Doc, (<+>), parens, text )
 
@@ -15,22 +18,26 @@ import Rel8.Query ( Query )
 import Rel8.Schema.Table ( TableSchema(..), ppTable )
 import Rel8.Statement.Select ( Optimized(..), ppPrimSelect )
 
+-- transformers
+import Control.Monad.Trans.State.Strict (State)
 
-ppFrom :: Query a -> Maybe (Doc, a)
+
+ppFrom :: Query a -> State Opaleye.Tag (Maybe (Doc, a))
 ppFrom = ppJoin "FROM"
 
 
-ppUsing :: Query a -> Maybe (Doc, a)
+ppUsing :: Query a -> State Opaleye.Tag (Maybe (Doc, a))
 ppUsing = ppJoin "USING"
 
 
-ppJoin :: String -> Query a -> Maybe (Doc, a)
+ppJoin :: String -> Query a -> State Opaleye.Tag (Maybe (Doc, a))
 ppJoin clause join = do
-  doc <- case ofrom of
-    Empty -> Nothing
-    Unit -> Just mempty
-    Optimized doc -> Just $ text clause <+> parens doc <+> ppTable alias
-  pure (doc, a)
+  (ofrom, a) <- ppPrimSelect join
+  pure $ do
+    doc <- case ofrom of
+      Empty -> Nothing
+      Unit -> Just mempty
+      Optimized doc -> Just $ text clause <+> parens doc <+> ppTable alias
+    pure (doc, a)
   where
     alias = TableSchema {name = "T1", schema = Nothing, columns = ()}
-    (ofrom, a) = ppPrimSelect join

--- a/src/Rel8/Statement/View.hs
+++ b/src/Rel8/Statement/View.hs
@@ -15,6 +15,12 @@ import qualified Hasql.Decoders as Hasql
 import qualified Hasql.Encoders as Hasql
 import qualified Hasql.Statement as Hasql
 
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
+
+-- pretty
+import Text.PrettyPrint ( Doc, (<+>), ($$), text )
+
 -- rel8
 import Rel8.Query ( Query )
 import Rel8.Schema.Name ( Selects )
@@ -22,12 +28,12 @@ import Rel8.Schema.Table ( TableSchema )
 import Rel8.Statement.Insert ( ppInto )
 import Rel8.Statement.Select ( ppSelect )
 
--- pretty
-import Text.PrettyPrint ( Doc, (<+>), ($$), text )
-
 -- text
 import qualified Data.Text as Text
 import Data.Text.Encoding ( encodeUtf8 )
+
+-- transformers
+import Control.Monad.Trans.State.Strict (evalState)
 
 
 data CreateView = Create | CreateOrReplace
@@ -72,7 +78,7 @@ ppCreateView schema query replace =
   createOrReplace replace <+>
   ppInto schema $$
   text "AS" <+>
-  ppSelect query
+  evalState (ppSelect query) Opaleye.start
   where
     createOrReplace Create = text "CREATE VIEW"
     createOrReplace CreateOrReplace = text "CREATE OR REPLACE VIEW"

--- a/src/Rel8/Statement/With.hs
+++ b/src/Rel8/Statement/With.hs
@@ -1,0 +1,169 @@
+{-# language BlockArguments #-}
+{-# language DataKinds #-}
+{-# language DerivingStrategies #-}
+{-# language FlexibleContexts #-}
+{-# language GADTs #-}
+{-# language GeneralizedNewtypeDeriving #-}
+{-# language LambdaCase #-}
+{-# language NamedFieldPuns #-}
+{-# language RankNTypes #-}
+{-# language RecordWildCards #-}
+{-# language ScopedTypeVariables #-}
+{-# language StandaloneKindSignatures #-}
+{-# language TypeApplications #-}
+
+module Rel8.Statement.With
+  ( With(..)
+  , runWith
+  , withInsert
+  , withQuery
+  , bindWith
+  , ppWith
+  , ppWithBinding
+  , withQuery
+  , showWith
+  )
+where
+
+-- base
+import Data.Foldable (fold, toList)
+import Data.Kind (Type)
+import Data.List.NonEmpty (NonEmpty, intersperse)
+import Prelude
+
+-- hasql
+import qualified Hasql.Decoders as Hasql
+import qualified Hasql.Encoders as Hasql
+import qualified Hasql.Statement as Hasql
+
+-- opaleye
+import qualified Opaleye.Internal.Tag as Opaleye
+
+-- pretty
+import Text.PrettyPrint
+  ( Doc
+  , (<+>)
+  , ($$)
+  , comma
+  , doubleQuotes
+  , hcat
+  , parens
+  , punctuate
+  , text
+  , vcat
+  )
+
+-- rel8
+import Rel8.Expr (Expr)
+import Rel8.Query (Query)
+import Rel8.Query.Each (each)
+import Rel8.Schema.Table (TableSchema (..))
+import Rel8.Table (Table)
+import Rel8.Table.Cols (fromCols)
+import Rel8.Table.Name (namesFromLabelsWithA, showNames)
+import Rel8.Table.Serialize ( Serializable, parse )
+import Rel8.Statement.Insert (Insert, ppInsert)
+import Rel8.Statement.Select (ppSelect)
+
+-- text
+import qualified Data.Text as Text
+import Data.Text.Encoding ( encodeUtf8 )
+
+-- transformers
+import Control.Monad.Trans.State.Strict (State, evalState, modify', runState, state)
+
+
+type With :: Type -> Type
+newtype With a = With (State WithState a)
+  deriving newtype (Functor, Applicative, Monad)
+
+
+withInsert :: Table Expr a => Insert (Query a) -> With (Query a)
+withInsert insert = bindWith (evalState (ppInsert insert) Opaleye.start)
+
+withQuery :: Table Expr a => Query a -> With (Query a)
+withQuery query = bindWith (evalState (ppSelect query) Opaleye.start)
+
+
+data WithState = WithState
+  { tag :: Opaleye.Tag
+  , bindings :: [(Doc, Doc)]
+  }
+
+
+initialWithState :: WithState
+initialWithState = WithState Opaleye.start []
+
+
+runWith :: forall exprs a. Serializable exprs a => With (Query exprs) -> Hasql.Statement () [a]
+runWith (With m) = Hasql.Statement bytes params decode prepare
+  where
+    bytes = encodeUtf8 (Text.pack sql)
+    params = Hasql.noParams
+    decode = Hasql.rowList (parse @exprs @a)
+    prepare = False
+    sql = show doc
+    doc = ppWith (reverse (bindings s')) (evalState (ppSelect query) (tag s'))
+      where
+        (query, s') = runState m initialWithState
+
+
+showWith :: Table Expr exprs => With (Query exprs) -> String
+showWith (With m) = show doc
+  where
+    doc = ppWith (bindings s') (evalState (ppSelect query) (tag s'))
+      where
+        (query, s') = runState m initialWithState
+
+
+bindWith :: Table Expr a => Doc -> With (Query a)
+bindWith q = With do
+  tag <- state \s -> let t = tag s in (t, s{tag = Opaleye.next t})
+  let
+    symbol labels = do
+      subtag <- Opaleye.fresh
+      let
+        suffix = Opaleye.tagWith tag (Opaleye.tagWith subtag "")
+      pure $ take (63 - length suffix) label ++ suffix
+      where
+        label = fold (intersperse "/" labels)
+    names = namesFromLabelsWithA symbol `evalState` Opaleye.start
+    relation = Opaleye.tagWith tag "statement"
+    columns = showNames names
+    query =
+      fromCols <$> each
+        TableSchema
+          { name = relation
+          , schema = Nothing
+          , columns = names
+          }
+  modify' \s -> s{bindings = (ppWithBinding relation columns, q):bindings s}
+  pure query
+
+
+ppWith :: [(Doc, Doc)] -> Doc -> Doc
+ppWith withs after = pre $$ after
+  where
+    pre = case withs of
+      [] -> mempty
+      _ ->
+        text "WITH" <+>
+        vcat (punctuate comma (map go withs))
+    go (with, before) =
+      with $$
+      text "AS" <+>
+      parens before
+
+
+ppWithBinding :: String -> NonEmpty String -> Doc
+ppWithBinding relation columns =
+  escape relation <+>
+  parens (hcat (punctuate comma (escape <$> toList columns)))
+
+
+escape :: String -> Doc
+escape = doubleQuotes . text . concatMap go
+  where
+    go = \case
+      '"' -> "\"\""
+      c -> [c]


### PR DESCRIPTION
The motivation behind this PR was to add support for PostreSQL's `WITH` syntax at the statement level, which gives the ability to, e.g., delete some rows from a table and then re-insert those deleted rows into another table, without any round-trips between the application and the database.

However, this necessitated some changes to how `Returning` works, which also bled into our interface for running queries, so it's quite an invasive change. `Returning` previously bundled two different concepts together: whether or not to generate a `RETURNING` clause in the SQL for a manipulation statement, and how to decode the returned rows (if any). It was necessary to break these concepts apart because with `WITH` we need the ability to generate manipulation statements with `RETURNING` clauses that are never actually decoded at all (the results just get passed to the next statement without touching the application).

This resulted in the `Rows` datatype which this PR introduces, which has the following values:

```haskell
type Rows :: Maybe Type -> Type -> Type
data Rows returning result where
  Void :: Rows returning ()
  RowsAffected :: Rows 'Nothing Int64
  Single :: Serializable exprs a => Rows ('Just exprs) a
  Maybe :: Serializable exprs a => Rows ('Just exprs) (Maybe a)
  List :: Serializable exprs a => Rows ('Just exprs) [a]
  Vector :: Serializable exprs a => Rows ('Just exprs) (Vector a)
```

`select`, `insert`, `update` and `delete` have all been replaced with a single (polymorphic) `run` function. `run` takes `Rows` as an argument (in addition to a statement such as a `Query` or an `Insert`) that specifies whether the result of the statement should be read as a single row or a list of rows (or a number of rows affected). This also gains us support for decoding the result of a query directly to a `Vector` which brings a performance improvement over lists for those who need it.

The `Single`, `Maybe`, `List` and `Vector` values for the `Rows` parameter can only be used with `Query`s or manipulation statements with a `RETURNING` clause — statements without a returning clause can only use `Void` or `RowsAffected`.

And finally, to actually generate compound statements using `WITH`, the `Rel8.Statement.Do` module exports a pseudo-monadic interface can be used with the `QualifiedDo` extension. This binds the result of a previous statement to a `Query`, which can then be used by a subsequent statement (e.g., as the `rows` parameter of an `Insert` statement).