### PR TITLE
Set up scriv and add pending changelog entries 

### DIFF
--- a/changelog.d/20230707_182829_ollie_scriv.md
+++ b/changelog.d/20230707_182829_ollie_scriv.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support PostgreSQL's `inet` type (which maps to the Haskell `NetAddr IP` type). ([#227](https://github.com/circuithub/rel8/pull/227))

--- a/changelog.d/20230707_183519_ollie_scriv.md
+++ b/changelog.d/20230707_183519_ollie_scriv.md
@@ -1,0 +1,3 @@
+### Added
+
+- `Rel8.materialize` and `Rel8.Tabulate.materialize`, which add a materialization/optimisation fence to `SELECT` statements by binding a query to a `WITH` subquery. Note that Rel8 doesn't currently add `MATERIALIZE` to this, but may in the future. ([#180](https://github.com/circuithub/rel8/pull/180))

--- a/changelog.d/20230707_184221_ollie_scriv.md
+++ b/changelog.d/20230707_184221_ollie_scriv.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed a bug with `catListTable` and `catNonEmptyTable` where invalid SQL could be produced. ([#240](https://github.com/circuithub/rel8/pull/240))

--- a/changelog.d/20230707_184703_ollie_scriv.md
+++ b/changelog.d/20230707_184703_ollie_scriv.md
@@ -1,0 +1,20 @@
+### Changed
+
+- Rel8's API regarding aggregation has changed significantly, and is now a closer match to Opaleye. 
+
+  The previous aggregation API had `aggregate` transform a `Table` from the `Aggregate` context back into the `Expr` context:
+
+  ```haskell
+  myQuery = aggregate do
+    a <- each tableA
+    return $ liftF2 (,) (sum (foo a)) (countDistinct (bar a))
+  ```
+
+  This API seemed convenient, but has some significant shortcomings. The new API requires an explicit `Aggregator` be passed to `aggregate`:
+
+  ```haskell
+  myQuery = aggregate (liftA2 (,) (sumOn foo) (countDistinctOn bar)) do
+    each tableA
+  ```
+
+  For more details, see [#235](https://github.com/circuithub/rel8/pull/235)

--- a/changelog.d/20230707_185221_ollie_scriv.md
+++ b/changelog.d/20230707_185221_ollie_scriv.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- A partial fix for nesting `catListTable`. The underlying issue in [#168](https://github.com/circuithub/rel8/issues/168) is still present, but we've made a bit of progress to reduce when this bug can happen. ([#243](https://github.com/circuithub/rel8/pull/243))

--- a/changelog.d/20230707_185339_ollie_scriv.md
+++ b/changelog.d/20230707_185339_ollie_scriv.md
@@ -1,0 +1,3 @@
+### Added
+
+- `Rel8.head`, `Rel8.headTable`, `Rel8.last`, `Rel8.lastExpr` for accessing the first/last elements of arrays and `ListTable`s. We have also added variants for non-empty arrays/`NonEmptyTable` with the `1` suffix (e.g., `head1`). ([#245](https://github.com/circuithub/rel8/pull/245))

--- a/changelog.d/20230707_185534_ollie_scriv.md
+++ b/changelog.d/20230707_185534_ollie_scriv.md
@@ -1,0 +1,39 @@
+### Added
+
+- Rel8 now has extensive support for `WITH` statements and data-modifying statements (https://www.postgresql.org/docs/current/queries-with.html#QUERIES-WITH-MODIFYING).
+
+  This work offers a lot of new power to Rel8. One new possibility is "moving" rows between tables, for example to archive rows in one table into a log table:
+
+  ```haskell
+  import Rel8
+
+  archive :: Statement ()
+  archive = do
+    deleted <- 
+      delete Delete
+        { from = mainTable
+        , using = pure ()
+        , deleteWhere = \foo -> fooId foo ==. lit 123
+        , returning = Returning id
+        }
+
+    insert Insert
+      { into = archiveTable
+      , rows = deleted
+      , onConflict = DoNothing
+      , returning = NoReturninvg
+      } 
+  ```
+
+  This `Statement` will compile to a single SQL statement - essentially:
+
+  ```sql
+  WITH deleted_rows (DELETE FROM main_table WHERE id = 123 RETURNING *)
+  INSERT INTO archive_table SELECT * FROM deleted_rows
+  ```
+   
+  This feature is a significant performant improvement, as it avoids an entire roundtrip.
+
+  This change has necessitated a change to how a `SELECT` statement is ran: `select` now will now produce a `Rel8.Statement`, which you have to `run` to turn it into a Hasql `Statement`. Rel8 offers a variety of `run` functions depending on how many rows need to be returned - see the various family of `run` functions in Rel8's documentation for more.
+
+  [#250](https://github.com/circuithub/rel8/pull/250)

--- a/changelog.d/20230707_191301_ollie_scriv.md
+++ b/changelog.d/20230707_191301_ollie_scriv.md
@@ -1,0 +1,3 @@
+### Added
+
+- - `Rel8.loop`, which allows writing `WITH .. RECURSIVE` queries. ([#180](https://github.com/circuithub/rel8/pull/180))

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,3 @@
+[scriv]
+format = md
+output_file = Changelog.md


### PR DESCRIPTION
[Scriv](https://scriv.readthedocs.io/) is a simple tool to manage building a changelog. We historically leave this far too late, which makes cutting releases tedious. The idea with Scriv is that one adds a changelog "fragment" to `changelog.d` (using `scriv create --edit --add`). Later, when we are ready to release, we run `scriv collect` which merges all fragments and prepends a new release entry to `Changelog.md`.