### PR TITLE
Switch to Opaleye 0.9.7.0

### DIFF
--- a/cabal.project.haskell-nix
+++ b/cabal.project.haskell-nix
@@ -2,9 +2,3 @@
 -- will interpret them as local packages, and try to build them when we cabal
 -- build. The only reason we have to specify these is for Haskell.nix to know to
 -- override these packages by fetching them rather than using Hackage.
-
-source-repository-package
-  type: git
-  location: https://github.com/tomjaguarpaw/haskell-opaleye
-  tag: version_0.9.7.0
-  --sha256: sha256-jOsDmVzHgvHwy3vBH+Bef/fvTK7J2YoC5LnEgecqWY8=

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -29,7 +29,7 @@ library
     , contravariant
     , hasql ^>= 1.6.1.2
     , network-ip
-    , opaleye ^>= 0.9.6.1
+    , opaleye ^>= 0.9.7.0
     , pretty
     , profunctors
     , product-profunctors


### PR DESCRIPTION
We actually require this now, so this updates the lower bound, and builds from Hackage rather than a `source-repository-package`.