### PR TITLE
Relax type of `distinctAggregate`

### DIFF
--- a/src/Rel8/Expr/Aggregate.hs
+++ b/src/Rel8/Expr/Aggregate.hs
@@ -299,9 +299,9 @@ nonEmptyCatExprOn f = lmap f nonEmptyCatExpr
 
 
 -- | 'distinctAggregate' modifies an 'Aggregator' to consider only distinct
--- values of a particular column.
-distinctAggregate :: Sql DBEq a
-  => Aggregator' fold i (Expr a) -> Aggregator' fold i (Expr a)
+-- values of each particular column. Note that this "distinction" only happens
+-- within each column individually, not across all columns simultaneously.
+distinctAggregate :: Aggregator' fold i a -> Aggregator' fold i a
 distinctAggregate (Aggregator fallback a) =
   Aggregator fallback (Opaleye.distinctAggregator a)
 


### PR DESCRIPTION
The `Sql DBEq a` constraint on the return type of the aggregator was wrong. It also isn't quite right to have a `EqTable i` constraint on the input type of the `Aggregator`, because technically what we want is a `Sql DBEq` constraint on whichever column(s) within `i` are used by aggregation functions, but we don't know which columns were used at this point. We could give `distinctAggregate` a type like `Sql DBEq i => Aggregator (Expr i) a` and make people run it through `lmap` manually, but that makes it impractical to use with `ListTable` without exposing more machinery. So we just drop the equality constraint for now.