### PR TITLE
docs: remove empty 'where' clause

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -357,7 +357,6 @@ focus on the /type/ of that query::
         author  <- each authorSchema
         project <- projectsForAuthor author
         return (author, project)
-        where
 
   >>> :t select conn authorsAndProjects
   select conn authorsAndProjects


### PR DESCRIPTION
This hanging 'where' clause  seems like a typo or the ghost of a proper where long gone