### PR TITLE
Fix link in haddocks

### DIFF
--- a/src/Rel8/Type/Num.hs
+++ b/src/Rel8/Type/Num.hs
@@ -41,7 +41,7 @@ instance DBNum Scientific
 
 -- | The class of database types that can be coerced to from integral
 -- expressions. This is a Rel8 concept, and allows us to provide
--- 'fromIntegral'.
+-- 'Rel8.Expr.Num.fromIntegral'.
 type DBIntegral :: Type -> Constraint
 class (DBNum a, DBOrd a) => DBIntegral a
 instance DBIntegral Int16


### PR DESCRIPTION
Previously this linked to Prelude.fromIntegral, but we mean Rel8.Num.fromIntegral