### PR TITLE
Remove `Table Expr b` constraint from `materialize`

### DIFF
--- a/src/Rel8/Query/Materialize.hs
+++ b/src/Rel8/Query/Materialize.hs
@@ -15,7 +15,6 @@ import Opaleye.With ( withMaterializedExplicit )
 import Rel8.Expr ( Expr )
 import Rel8.Query ( Query )
 import Rel8.Query.Opaleye ( fromOpaleye, toOpaleye )
-import Rel8.Query.Rebind ( rebind )
 import Rel8.Table ( Table )
 import Rel8.Table.Opaleye ( unpackspec )
 
@@ -31,10 +30,9 @@ import Rel8.Table.Opaleye ( unpackspec )
 -- specifically the @WITH _ AS MATERIALIZED (_)@ form introduced in PostgreSQL
 -- 12. This means that 'materialize' can only be used with PostgreSQL 12 or
 -- newer.
-materialize :: (Table Expr a, Table Expr b)
-  => Query a -> (Query a -> Query b) -> Query b
+materialize :: Table Expr a => Query a -> (Query a -> Query b) -> Query b
 materialize query f =
-  (>>= rebind "with") . fromOpaleye $
+  fromOpaleye $
     withMaterializedExplicit unpackspec
       (toOpaleye query')
       (toOpaleye . f . fromOpaleye)

--- a/src/Rel8/Tabulate.hs
+++ b/src/Rel8/Tabulate.hs
@@ -628,7 +628,7 @@ difference a b = a <* absent b
 
 
 -- | 'Q.materialize' for 'Tabulation's.
-materialize :: (Table Expr k, Table Expr a, Table Expr b)
+materialize :: (Table Expr k, Table Expr a)
   => Tabulation k a -> (Tabulation k a -> Query b) -> Query b
 materialize tabulation f = case peek tabulation of
   Tabulation query -> do


### PR DESCRIPTION
Not only is this not necessary, it can actually act as a barrier to optimisation. The reason I added it was because it seemed like a cheap way to stop someone writing `query' <- materialize query id` — if you return the materialized query from `materialized`, it won't work. Really we would need some sort of `runST` type trick here to do this properly, but that would be too invasive a change.