### PR TITLE
Fix case-sensitive match operator

### DIFF
--- a/src/Rel8/Expr/Text.hs
+++ b/src/Rel8/Expr/Text.hs
@@ -58,9 +58,9 @@ infixr 6 ++.
 
 -- | Matches regular expression, case sensitive
 --
--- Corresponds to the @~.@ operator.
+-- Corresponds to the @~@ operator.
 (~.) :: Expr Text -> Expr Text -> Expr Bool
-(~.) = binaryOperator "~."
+(~.) = binaryOperator "~"
 infix 2 ~.
 
 


### PR DESCRIPTION
Looks like there's a typo in the case-sensitive match [operator](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP). I assume you still want to keep the period on the Haskell function?