### PR TITLE
Set NOINLINE pragmas on Generics derived default implementations of Rel8able

### DIFF
--- a/changelog.d/20241018_112157_teofilcamarasu_try_noinline.md
+++ b/changelog.d/20241018_112157_teofilcamarasu_try_noinline.md
@@ -1,0 +1,5 @@
+### Added
+
+- Add `NOINLINE` pragmas to `Generic` derived default methods of `Rel8able`. This should speed up
+  compilation times. If users wish for these methods to be `INLINE`d, they can override with a
+  pragma in their own code.


### PR DESCRIPTION
This is an easy change that should speed up compilation for end-users without having to make any changes to their code.

See Note [Generics and Inlining]