### PR TITLE
Cut 1.6.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,46 @@
 
+<a id='changelog-1.6.0.0'></a>
+# 1.6.0.0 — 2024-12-13
+
+## Removed
+
+- Remove `Table Expr b` constraint from `materialize`. ([#334](https://github.com/circuithub/rel8/pull/334))
+
+## Added
+
+- Support GHC-9.10. ([#340](https://github.com/circuithub/rel8/pull/340))
+
+- Support hasql-1.8 ([#345](https://github.com/circuithub/rel8/pull/345))
+
+- Add `aggregateJustTable`, `aggregateJustTable` aggregator functions. These provide another way to do aggregation of `MaybeTable`s than the existing `aggregateMaybeTable` function. ([#333](https://github.com/circuithub/rel8/pull/333))
+
+- Add `aggregateLeftTable`, `aggregateLeftTable1`, `aggregateRightTable` and `aggregateRightTable1` aggregator functions. These provide another way to do aggregation of `EitherTable`s than the existing `aggregateEitherTable` function. ([#333](https://github.com/circuithub/rel8/pull/333))
+
+- Add `aggregateThisTable`, `aggregateThisTable1`, `aggregateThatTable`, `aggregateThatTable1`, `aggregateThoseTable`, `aggregateThoseTable1`, `aggregateHereTable`, `aggregateHereTable1`, `aggregateThereTable` and `aggregateThereTable1` aggregation functions. These provide another way to do aggregation of `TheseTable`s than the existing `aggregateTheseTable` function. ([#333](https://github.com/circuithub/rel8/pull/333))
+
+- Add `rawFunction`, `rawBinaryOperator`, `rawAggregateFunction`, `unsafeCoerceExpr`, `unsafePrimExpr`, `unsafeSubscript`, `unsafeSubscripts` — these give more options for generating SQL expressions that Rel8 does not support natively. ([#331](https://github.com/circuithub/rel8/pull/331))
+
+- Expose `unsafeUnnullify` and `unsafeUnnullifyTable` from `Rel8`. ([#343](https://github.com/circuithub/rel8/pull/343))
+
+- Expose `listOf` and `nonEmptyOf`. ([#330](https://github.com/circuithub/rel8/pull/330))
+
+- Add `NOINLINE` pragmas to `Generic` derived default methods of `Rel8able`. This should speed up
+  compilation times. If users wish for these methods to be `INLINE`d, they can override with a
+  pragma in their own code. ([#346](https://github.com/circuithub/rel8/pull/346))
+
+## Fixed
+
+- `JSONEncoded` should be encoded as `json` not `jsonb`. ([#347](https://github.com/circuithub/rel8/pull/347))
+
+- Disallow NULL characters in Hedgehog generated text values. ([#339](https://github.com/circuithub/rel8/pull/339))
+
+- Fix fromRational bug. ([#338](https://github.com/circuithub/rel8/pull/338))
+
+- Fix regex match operator. ([#336](https://github.com/circuithub/rel8/pull/336))
+
+- Fix some documentation formatting issues. ([#332](https://github.com/circuithub/rel8/pull/332)), ([#329](https://github.com/circuithub/rel8/pull/329)), ([#327](https://github.com/circuithub/rel8/pull/327)), and ([#318](https://github.com/circuithub/rel8/pull/318))
+
+
 <a id='changelog-1.5.0.0'></a>
 # 1.5.0.0 — 2024-03-19
 

--- a/changelog.d/20231009_170238_shane.obrien_aggregateFunction.md
+++ b/changelog.d/20231009_170238_shane.obrien_aggregateFunction.md
@@ -1,3 +1,0 @@
-### Added
-
-- `aggregationFunction`, which allows custom aggregation functions to be used.

--- a/changelog.d/20231009_170616_shane.obrien_mode.md
+++ b/changelog.d/20231009_170616_shane.obrien_mode.md
@@ -1,3 +1,0 @@
-### Added
-
-- Add support for ordered-set aggregation functions, including `mode`, `percentile`, `percentileContinuous`, `hypotheticalRank`, `hypotheticalDenseRank`, `hypotheticalPercentRank` and `hypotheticalCumeDist`.

--- a/changelog.d/20240527_022306_shane.obrien_aggregateJustTable.md
+++ b/changelog.d/20240527_022306_shane.obrien_aggregateJustTable.md
@@ -1,5 +1,0 @@
-### Added
-
-- Add `aggregateJustTable`, `aggregateJustTable` aggregator functions. These provide another way to do aggregation of `MaybeTable`s than the existing `aggregateMaybeTable` function.
-- Add `aggregateLeftTable`, `aggregateLeftTable1`, `aggregateRightTable` and `aggregateRightTable1` aggregator functions. These provide another way to do aggregation of `EitherTable`s than the existing `aggregateEitherTable` function.
-- Add `aggregateThisTable`, `aggregateThisTable1`, `aggregateThatTable`, `aggregateThatTable1`, `aggregateThoseTable`, `aggregateThoseTable1`, `aggregateHereTable`, `aggregateHereTable1`, `aggregateThereTable` and `aggregateThereTable1` aggregation functions. These provide another way to do aggregation of `TheseTable`s than the existing `aggregateTheseTable` function.

--- a/changelog.d/20240701_173914_shane.obrien_raw.md
+++ b/changelog.d/20240701_173914_shane.obrien_raw.md
@@ -1,4 +1,0 @@
-### Added
-
-- `rawFunction`, `rawBinaryOperator`, `rawAggregateFunction`, `unsafeCoerceExpr`, `unsafePrimExpr`, `unsafeSubscript`, `unsafeSubscripts` — these give more options for generating SQL expressions that Rel8 does not support natively.
-

--- a/changelog.d/20240822_184927_teofilcamarasu_ghc_9_10.md
+++ b/changelog.d/20240822_184927_teofilcamarasu_ghc_9_10.md
@@ -1,3 +1,0 @@
-### Added
-
-- Support GHC 9.10

--- a/changelog.d/20240918_124205_shane.obrien.md
+++ b/changelog.d/20240918_124205_shane.obrien.md
@@ -1,3 +1,0 @@
-### Added
-
-- Expose `unsafeUnnullify` and `unsafeUnnullifyTable` from `Rel8`.

--- a/changelog.d/20241008_181955_teofilcamarasu_hasql_1_8.md
+++ b/changelog.d/20241008_181955_teofilcamarasu_hasql_1_8.md
@@ -1,4 +1,0 @@
-### Added
-
-- Support hasql-1.8
-

--- a/changelog.d/20241018_112157_teofilcamarasu_try_noinline.md
+++ b/changelog.d/20241018_112157_teofilcamarasu_try_noinline.md
@@ -1,5 +1,0 @@
-### Added
-
-- Add `NOINLINE` pragmas to `Generic` derived default methods of `Rel8able`. This should speed up
-  compilation times. If users wish for these methods to be `INLINE`d, they can override with a
-  pragma in their own code.

--- a/changelog.d/20241018_113208_teofilcamarasu_jsonb.md
+++ b/changelog.d/20241018_113208_teofilcamarasu_jsonb.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- `JSONEncoded` should be encoded as `json` not `jsonb`. Resolves #344

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -1,6 +1,6 @@
 cabal-version:       2.0
 name:                rel8
-version:             1.5.0.0
+version:             1.6.0.0
 synopsis:            Hey! Hey! Can u rel8?
 license:             BSD3
 license-file:        LICENSE


### PR DESCRIPTION
I think we need a major version bump because we've changed the type of an exported entity
> - Remove `Table Expr b` constraint from `materialize`.

I used scriv to generate the changelog and then added links to PRs manually and added manual entries for stuff that was missing. All commits should have a corresponding entry

I ran `cabal update && cabal outdated` and we seem to be fine for bounds