### PR TITLE
TableSchema no longer has a schema field

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -127,7 +127,6 @@ associated with the ``Author`` type::
   authorSchema :: TableSchema (Author Name)
   authorSchema = TableSchema
     { name = "author"
-    , schema = Nothing
     , columns = Author
         { authorId = "author_id"
         , authorName = "name"
@@ -140,7 +139,6 @@ And likewise for ``project`` and ``Project``::
   projectSchema :: TableSchema (Project Name)
   projectSchema = TableSchema
     { name = "project"
-    , schema = Nothing
     , columns = Project
         { projectAuthorId = "author_id"
         , projectName = "name"
@@ -153,7 +151,6 @@ information from your ``Rel8able`` type::
   projectSchema :: TableSchema (Project Name)
   projectSchema = TableSchema
     { name = "project"
-    , schema = Nothing
     , columns = namesFromLabels @(Project Name)
     }
 

--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -552,8 +552,7 @@ import Rel8.Window
 -- thingSchema :: TableSchema (ADT Thing Name)
 -- thingSchema =
 --   TableSchema
---     { schema = Nothing,
---       name = \"thing\",
+--     { name = \"thing\",
 --       columns =
 --         nameADT @Thing
 --           \"tag\"


### PR DESCRIPTION
Presumbly this was changed in version 1.6.0.0. I don't think it's worth adding a documentation note here, but maybe it should?