### PR TITLE
Add standard float column type names to DBType docs

### DIFF
--- a/src/Rel8/Type.hs
+++ b/src/Rel8/Type.hs
@@ -196,7 +196,7 @@ instance DBType Int64 where
     }
 
 
--- | Corresponds to @float4@
+-- | Corresponds to @float4@ and @real@
 instance DBType Float where
   typeInformation = TypeInformation
     { encode = \x -> Opaleye.ConstExpr
@@ -214,7 +214,7 @@ instance DBType Float where
     }
 
 
--- | Corresponds to @float8@
+-- | Corresponds to @float8@ and @double precision@
 instance DBType Double where
   typeInformation = TypeInformation
     { encode = \x -> Opaleye.ConstExpr


### PR DESCRIPTION
[The PostgreSQL docs](https://www.postgresql.org/docs/current/datatype-numeric.html) refer to floating point types as `real` or `double precision`, so I've added them to the `DBType` docs for `Float` and `Double` to make the mapping clear.