### PR TITLE
Remove `Enumable` super-class from `DBEnum`

### DIFF
--- a/changelog.d/20250512_114707_shane.obrien_fix_DBEnum.md
+++ b/changelog.d/20250512_114707_shane.obrien_fix_DBEnum.md
@@ -1,0 +1,8 @@
+### Changed
+
+- Some changes were made to the `DBEnum` type class:
+
+  * `Enumable` was removed as a superclass constraint. It is still used to provide the default implementation of the `DBEnum` class.
+  * A new method, `enumerate`, was added to the `DBEnum` class (with the default implementation provided by `Enumable`).
+
+  This is unlikely to break any existing `DBEnum` instances, it just allows some instances that weren't possible before (e.g., for types that are not `Generic`).


### PR DESCRIPTION
We still use `Enumable` in the signatures of the default implementation of the `DBEnum` class. We also add a method `enumerate` to that class to do away with the need for the superclass.