### PR TITLE
Escape tabs and newlines in array and composite text encoding

### DIFF
--- a/src/Rel8/Type/Array.hs
+++ b/src/Rel8/Type/Array.hs
@@ -196,9 +196,10 @@ buildArray delimiter elements =
       Just a
         | BS.null a -> "\"\""
         | CI.mk a == "null" -> escaped
-        | BS.any (A.inClass (delimiter : "\\\"{}")) a -> escaped
+        | BS.any (A.inClass escapeClass) a -> escaped
         | otherwise -> unescaped
         where
+          escapeClass = delimiter : "\\\"{}\t\n"
           unescaped = B.byteString a
           escaped =
             B.char8 '"' <> BS.foldr ((<>) . escape) mempty a <> B.char8 '"'

--- a/src/Rel8/Type/Composite.hs
+++ b/src/Rel8/Type/Composite.hs
@@ -245,10 +245,11 @@ buildRow elements =
   where
     element a
         | BS.null a = "\"\""
-        | BS.all (A.notInClass ",\\\"()") a = B.byteString a
+        | BS.all (A.notInClass escapeClass) a = B.byteString a
         | otherwise =
             B.char8 '"' <> BS.foldr ((<>) . escape) mempty a <> B.char8 '"'
         where
+          escapeClass = ",\\\"()\t\n"
           escape = \case
             '"' -> B.string7 "\"\""
             '\\' -> B.string7 "\\\\"


### PR DESCRIPTION
This fixes #384.