### PR TITLE
Wrap example ADT fields in Column

### DIFF
--- a/src/Rel8.hs
+++ b/src/Rel8.hs
@@ -534,11 +534,11 @@ import Rel8.Window
 -- data Thing f = ThingEmployer (Employer f) | ThingPotato (Potato f) | Nullary
 --     deriving stock Generic
 --
--- data Employer f = Employer { employerId :: f Int32, employerName :: f Text}
+-- data Employer f = Employer { employerId :: Column f Int32, employerName :: Column f Text}
 --   deriving stock Generic
 --   deriving anyclass Rel8able
 --
--- data Potato f = Potato { size :: f Int32, grower :: f Text }
+-- data Potato f = Potato { size :: Column f Int32, grower :: Column f Text }
 --   deriving stock Generic
 --   deriving anyclass Rel8able
 -- @


### PR DESCRIPTION
The Haddocks for `module Rel8` describe how you can define sum types with all the relevant Rel8 plumbing, using an example. But the inner type uses plain `f`:

```haskell
data Thing f = ThingEmployer (Employer f) | ThingPotato (Potato f) | Nullary
    deriving stock Generic

data Employer f = Employer { employerId :: f Int32, employerName :: f Text}
-- ...
```

instead of `Column f` which erases the `Result ~ Identity` wrapper, for ergonomics. Probably it should be using that. (I can't find any other cases in the docs that _don't_ wrap a column in `Column`.)

Doesn't impact the Haddock example that uses this data type.