### PR TITLE
Support GHC 9.14 and semialign >= 1.4

### DIFF
--- a/changelog.d/20260616_150020_cgeorgii_support_ghc_9_14.md
+++ b/changelog.d/20260616_150020_cgeorgii_support_ghc_9_14.md
@@ -1,0 +1,3 @@
+### Added
+
+- Support GHC-9.14 and `semialign >= 1.4`.

--- a/rel8.cabal
+++ b/rel8.cabal
@@ -21,7 +21,7 @@ library
   build-depends:
       aeson
     , attoparsec
-    , base >= 4.16 && < 4.22
+    , base >= 4.16 && < 4.23
     , base16 >= 1.0
     , base-compat >= 0.11 && < 0.15
     , bifunctors

--- a/src/Rel8/Schema/HTable/Vectorize.hs
+++ b/src/Rel8/Schema/HTable/Vectorize.hs
@@ -67,7 +67,7 @@ import Rel8.Type.Information ( TypeInformation )
 
 -- semialign
 import Data.Align (Semialign, alignWith)
-import Data.Zip (Unzip, Zip, Zippy(..), zipWith)
+import Data.Zip (Unzip, Zip, Zippy(..), unzipWith, zipWith)
 
 -- semigroupoids
 import Data.Functor.Apply (Apply)
@@ -203,3 +203,7 @@ instance Semialign (First a) where
 
 instance Zip (First a) where
   zipWith _ (First a) _ = First a
+
+
+instance Unzip (First a) where
+  unzipWith _ (First a) = (First a, First a)

--- a/src/Rel8/Statement.hs
+++ b/src/Rel8/Statement.hs
@@ -8,6 +8,7 @@
 {-# language RecordWildCards #-}
 {-# language ScopedTypeVariables #-}
 {-# language StandaloneKindSignatures #-}
+{-# language TypeAbstractions #-}
 {-# language TypeApplications #-}
 
 module Rel8.Statement


### PR DESCRIPTION
Hey there! We're happy users of  `rel8` in our effect library [atelier](https://github.com/atelier-hub/atelier), thanks for the work you've put into it!

While trying to support GHC 9.14 I hit a dependency issue with it so I thought I'd contribute a fix.

The tests passed locally and `nix flake check` too. I also added a changelog following what was done for 9.12 but let me know if there's anything else I have to do.

Closes #402

---

GHC 9.14 moved binding type variables in constructor patterns from `TypeApplications` to the `TypeAbstractions` extension, so `Rel8.Statement` fails to compile with 'Illegal invisible type pattern'. Enable `TypeAbstractions` there.

`semialign` 1.4 makes `Unzip` a superclass of `Semialign`, so the internal 'First' vectorizer newtype needs an Unzip instance.

Also widen the base upper bound to < 4.23 to admit base 4.22 (GHC 9.14).