### PR TITLE
Suppress annoying missed specialisation warning

### DIFF
--- a/rel8-internal/rel8-internal.cabal
+++ b/rel8-internal/rel8-internal.cabal
@@ -58,6 +58,7 @@ library
     -Wno-missing-deriving-strategies
     -Wno-term-variable-capture
     -Wno-missed-specializations
+    -Wno-all-missed-specializations
 
   hs-source-dirs:
     src

--- a/rel8/rel8.cabal
+++ b/rel8/rel8.cabal
@@ -41,6 +41,7 @@ library
     -Wno-missing-role-annotations
     -Wno-missing-deriving-strategies
     -Wno-term-variable-capture
+    -Wno-all-missed-specializations
 
   hs-source-dirs:
     src


### PR DESCRIPTION
This warning doesn't tell us anything interesting and it spans our build logs. So, let's just turn it off