### PR TITLE
Add `notElem` and `notElem1` to `Rel8.Array`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,19 +4,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3.5.3
+    - uses: actions/checkout@v5
       with:
           persist-credentials: false
           submodules: true
 
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v31
       with:
         nix_path: nixpkgs=channel:nixos-unstable
         extra_nix_config: |
-          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-          substituters = https://cache.nixos.org/ https://cache.iog.io
+          trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk=
+          substituters = https://cache.nixos.org/ https://cache.iog.io https://cache.zw3rk.com
 
-    - uses: cachix/cachix-action@v12
+    - uses: cachix/cachix-action@v17
       with:
         name: rel8
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/changelog.d/20260820_000000_notelem.md
+++ b/changelog.d/20260820_000000_notelem.md
@@ -1,0 +1,11 @@
+### Added
+
+- Added `notElem` and `notElem1` to `Rel8.Array`.
+
+### Fixed
+
+- `elem` and `elem1` now use `IS NOT DISTINCT FROM` semantics (matching `(==.)`) when the element type is nullable, so `null` is found in an array containing `null`. Previously they were implemented with the array containment operator `<@`, which never matches `null`.
+
+### Changed
+
+- `rel8` now requires at least version `0.10.8.0` of `opaleye`

--- a/flake.lock
+++ b/flake.lock
@@ -16,23 +16,6 @@
         "type": "github"
       }
     },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -118,31 +101,14 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1755735907,
-        "narHash": "sha256-8fOqP45pBWQVFW4tBGgWw1vJmRRBSrQX1TOkCIRZUlw=",
+        "lastModified": 1787185184,
+        "narHash": "sha256-jE0z2/igTUWAfB67gCp0UXNzyckZkAXXFMRTmy+p/00=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "6313548135c7dc5daea2ae1ed1d0dd1afa3d485e",
+        "rev": "b0ca293fbd185ddfcd83f9b9be91aafccf90e346",
         "type": "github"
       },
       "original": {
@@ -154,11 +120,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1755735896,
-        "narHash": "sha256-X4HTWcv6vgx6EncLyyJJdaNTkL8F8P69HAMaEgZLYhg=",
+        "lastModified": 1787185173,
+        "narHash": "sha256-jjwhthPBr45A8xxkcPuETHRtFql+wGX+Z5ONlC/mMVQ=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "54203507c2141dfea4463ba5c4015f11f2c2a503",
+        "rev": "e1a69bbb2ee87a1c11a03b042dff43845a92a01d",
         "type": "github"
       },
       "original": {
@@ -184,23 +150,40 @@
         "type": "github"
       }
     },
+    "hackage-overlay-repo-tool": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1671663228,
+        "narHash": "sha256-GKeke8FT9w2u6J9aI4eN3mOV0BURHiytQAEir4/4M1Q=",
+        "owner": "bgamari",
+        "repo": "hackage-overlay-repo-tool",
+        "rev": "f60aa0d497961745a503ddea2adb0facb58376e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bgamari",
+        "repo": "hackage-overlay-repo-tool",
+        "type": "github"
+      }
+    },
     "haskellNix": {
       "inputs": {
         "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hackage-for-stackage": "hackage-for-stackage",
         "hackage-internal": "hackage-internal",
+        "hackage-overlay-repo-tool": "hackage-overlay-repo-tool",
+        "head-hackage": "head-hackage",
         "hls": "hls",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.10": "hls-2.10",
         "hls-2.11": "hls-2.11",
+        "hls-2.12": "hls-2.12",
         "hls-2.2": "hls-2.2",
         "hls-2.3": "hls-2.3",
         "hls-2.4": "hls-2.4",
@@ -220,22 +203,42 @@
         "nixpkgs-2405": "nixpkgs-2405",
         "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-2511": "nixpkgs-2511",
+        "nixpkgs-2605": "nixpkgs-2605",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1755737525,
-        "narHash": "sha256-BVHCMhwjwl+uxDUgQOQu3EoGRwcDYLuJ/6DNTgWDSys=",
+        "lastModified": 1787187056,
+        "narHash": "sha256-vXvBKJ6RkfuHsGb5s9mQbsnSKUR95t8XSy5Yz6Rhkbg=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a808cbd430a74c00a0e5959d384e1a11e2ea1e2a",
+        "rev": "0ead4edaa8d277627e3ab5b6c03ad65c294e0b8d",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
         "type": "github"
+      }
+    },
+    "head-hackage": {
+      "flake": false,
+      "locked": {
+        "host": "gitlab.haskell.org",
+        "lastModified": 1780387533,
+        "narHash": "sha256-oifEa/JYg8ZLUtkbM8HVzKmqCcT9QxaDmG0ex2qT0Ng=",
+        "owner": "ghc",
+        "repo": "head.hackage",
+        "rev": "a50bec6c7722f774415bc0f0a0e64f6e2b8989b7",
+        "type": "gitlab"
+      },
+      "original": {
+        "host": "gitlab.haskell.org",
+        "owner": "ghc",
+        "repo": "head.hackage",
+        "type": "gitlab"
       }
     },
     "hls": {
@@ -318,6 +321,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.12": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1758709460,
+        "narHash": "sha256-xkI8MIIVEVARskfWbGAgP5sHG/lyeKnkm0LIOJ19X5w=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "7d983de4fa7ff54369f6dd31444bdb9869aec83e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.12.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -477,11 +497,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1755040634,
-        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
+        "lastModified": 1786665587,
+        "narHash": "sha256-wyc/2cAic/m+xXVbjiJJe3XICe5yHUg1lGWoylFw/Dg=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
+        "rev": "6278b39451f6ddd81e1926389a99bfbcdb3f6c1c",
         "type": "github"
       },
       "original": {
@@ -541,11 +561,11 @@
     },
     "nixpkgs-2411": {
       "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "lastModified": 1751290243,
+        "narHash": "sha256-kNf+obkpJZWar7HZymXZbW+Rlk3HTEIMlpc6FCNz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "rev": "5ab036a8d97cb9476fbe81b09076e6e91d15e1b6",
         "type": "github"
       },
       "original": {
@@ -557,11 +577,11 @@
     },
     "nixpkgs-2505": {
       "locked": {
-        "lastModified": 1748852332,
-        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "lastModified": 1764560356,
+        "narHash": "sha256-M5aFEFPppI4UhdOxwdmceJ9bDJC4T6C6CzCK1E2FZyo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "rev": "6c8f0cca84510cc79e09ea99a299c9bc17d03cb6",
         "type": "github"
       },
       "original": {
@@ -571,13 +591,45 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1748856973,
-        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "lastModified": 1782904953,
+        "narHash": "sha256-ESJ4VgytmAt+98YLM8466luln4HyEZ9Q36b9+Bb4P5w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "rev": "0921fdb3e13e40fe25fbc52b89661a9d6d32ac68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2605": {
+      "locked": {
+        "lastModified": 1784432872,
+        "narHash": "sha256-n3gKTBIV4ZA5VQpUakffBe3KGu4+mhPoA34rrqS0GkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fd1462031fdee08f65fd0b4c6b64e22239a77870",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-26.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {
@@ -617,11 +669,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1755735102,
-        "narHash": "sha256-/oZzMO5tdwz0V3uLRI5N9BrMEQc6/MFOpDfHRMRehEI=",
+        "lastModified": 1787184585,
+        "narHash": "sha256-sOyE6tI0wDKwTaRj6tu/apnCSYJfOiX2WiALthRBhrU=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "999a41c7e94d417cd507977e1050a18f3a7a2424",
+        "rev": "4383fc89bf1c88496a72da9846604ed1df996b34",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,10 +5,12 @@
     extra-substituters = [
       "https://rel8.cachix.org"
       "https://cache.iog.io"
+      "https://cache.zw3rk.com"
     ];
     extra-trusted-public-keys = [
       "hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="
       "rel8.cachix.org-1:C/hVFTPHIOp7S/jRleuLL0Cg/dE0dQzEuEB5szaszTc="
+      "loony-tools:pr9m4BkM/5/eSTZlkQyRt57Jz7OMBxNSUiMC4FkcNfk="
     ];
   };
 
@@ -28,7 +30,7 @@
         };
 
         rel8 = pkgs.haskell-nix.project {
-          compiler-nix-name = "ghc9121";
+          compiler-nix-name = "ghc9141";
 
           cabalProjectLocal = builtins.readFile ./cabal.project.haskell-nix;
 

--- a/rel8/rel8.cabal
+++ b/rel8/rel8.cabal
@@ -23,7 +23,7 @@ library
     , bifunctors
     , bytestring
     , comonad
-    , opaleye ^>= 0.10.2.1
+    , opaleye ^>= 0.10.8.0
     , profunctors
     , product-profunctors
     , semigroupoids

--- a/rel8/src/Rel8/Array.hs
+++ b/rel8/src/Rel8/Array.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MonoLocalBinds #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Rel8.Array
   (
@@ -10,7 +12,7 @@ module Rel8.Array
   , index, indexExpr
   , last, lastExpr
   , length, lengthExpr
-  , elem
+  , elem, notElem
 
     -- ** @NonEmptyTable@
   , NonEmptyTable
@@ -18,7 +20,7 @@ module Rel8.Array
   , index1, index1Expr
   , last1, last1Expr
   , length1, length1Expr
-  , elem1
+  , elem1, notElem1
 
     -- ** Unsafe
   , unsafeSubscript
@@ -27,34 +29,74 @@ module Rel8.Array
 where
 
 -- base
+import Data.Int (Int32)
 import Data.List.NonEmpty (NonEmpty)
-import Prelude hiding (elem, head, last, length)
+import Prelude hiding (elem, head, last, length, notElem)
+
+-- opaleye
+import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
 
 -- rel8
 import Rel8.Internal.Expr (Expr)
-import Rel8.Internal.Expr.Array (listOf, nonEmptyOf)
-import Rel8.Internal.Expr.Function (rawBinaryOperator)
+import Rel8.Internal.Expr.Bool (not_)
+import Rel8.Internal.Expr.Function (rawFunction)
 import Rel8.Internal.Expr.List
 import Rel8.Internal.Expr.NonEmpty
+import Rel8.Internal.Expr.Null (isNonNull, isNull)
+import Rel8.Internal.Expr.Opaleye (fromPrimExpr, toPrimExpr)
 import Rel8.Internal.Expr.Subscript
-import Rel8.Internal.Schema.Null (Sql)
+import Rel8.Internal.Schema.Null (Nullity (NotNull, Null), Sql, nullable)
 import Rel8.Internal.Table.List
 import Rel8.Internal.Table.NonEmpty
+import Rel8.Internal.Type (DBType)
 import Rel8.Internal.Type.Eq (DBEq)
 
 
 -- | @'elem' a as@ tests whether @a@ is an element of the list @as@.
 elem :: Sql DBEq a => Expr a -> Expr [a] -> Expr Bool
-elem = (<@) . listOf . pure
-  where
-    (<@) = rawBinaryOperator "<@"
+elem = memberOf
 infix 4 `elem`
 
 
 -- | @'elem1' a as@ tests whether @a@ is an element of the non-empty list
 -- @as@.
 elem1 :: Sql DBEq a => Expr a -> Expr (NonEmpty a) -> Expr Bool
-elem1 = (<@) . nonEmptyOf . pure
-  where
-    (<@) = rawBinaryOperator "<@"
+elem1 = memberOf
 infix 4 `elem1`
+
+
+-- | @'notElem' a as@ tests whether @a@ is not an element of the list @as@.
+notElem :: Sql DBEq a => Expr a -> Expr [a] -> Expr Bool
+notElem = notMemberOf
+infix 4 `notElem`
+
+
+-- | @'notElem1' a as@ tests whether @a@ is not an element of the non-empty
+-- list @as@.
+notElem1 :: Sql DBEq a => Expr a -> Expr (NonEmpty a) -> Expr Bool
+notElem1 = notMemberOf
+infix 4 `notElem1`
+
+
+memberOf :: forall a t. (Sql DBEq a, DBType (t a))
+  => Expr a -> Expr (t a) -> Expr Bool
+memberOf = case nullable @a of
+  Null -> \ma mas -> isNonNull (position mas ma)
+  NotNull -> eqAny
+
+
+notMemberOf :: forall a t. (Sql DBEq a, DBType (t a))
+  => Expr a -> Expr (t a) -> Expr Bool
+notMemberOf = case nullable @a of
+  Null -> \ma mas -> isNull (position mas ma)
+  NotNull -> \a as -> not_ (eqAny a as)
+
+
+position :: (DBType (t (Maybe a)), DBType a)
+  => Expr (t (Maybe a)) -> Expr (Maybe a) -> Expr (Maybe Int32)
+position as a = rawFunction "array_position" (as, a)
+
+
+eqAny :: Expr a -> Expr as -> Expr Bool
+eqAny a as =
+  fromPrimExpr (Opaleye.AnyExpr (Opaleye.:==) (toPrimExpr a) (toPrimExpr as))

--- a/rel8/src/Rel8/Expr/Text.hs
+++ b/rel8/src/Rel8/Expr/Text.hs
@@ -1,6 +1,3 @@
-{-# language DataKinds #-}
-{-# language OverloadedStrings #-}
-
 module Rel8.Expr.Text
   (
     -- * String concatenation
@@ -25,19 +22,7 @@ module Rel8.Expr.Text
 where
 
 -- base
-import Data.Bool ( Bool )
-import Data.Int ( Int32 )
-import Data.Maybe ( Maybe( Nothing, Just ) )
-import Prelude ( flip )
-
--- bytestring
-import Data.ByteString ( ByteString )
-
--- opaleye
-import qualified Opaleye.Internal.HaskellDB.PrimQuery as Opaleye
+import Prelude hiding (length, repeat, reverse)
 
 -- rel8
-import Rel8.Internal.Expr ( Expr )
-import Rel8.Internal.Expr.Function (binaryOperator, function)
-import Rel8.Internal.Expr.Opaleye (zipPrimExprsWith)
 import Rel8.Internal.Expr.Text 


### PR DESCRIPTION
`elem` and `elem1` (along with their new counterparts) are now implemented using PostgreSQL's `ANY` operator. This necessitates Opaleye 0.10.8.0 which adds the `AnyExpr` constructor to `PrimExpr`.

We also fix `elem` and `elem1`'s behaviour for nullable data.